### PR TITLE
ci(release): standardize release packages and notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,95 @@ jobs:
             publish="true"
           fi
 
-          if [[ "$package_set" == "smoke" || "$package_set" == "standard" ]]; then
-            package_matrix='{"include":[{"artifact":"macos-x64","os":"macos-15-intel","preset":"vcpkg-osx-x64-release","package_preset":"vcpkg-osx-x64-dmg","qt_version":"6.9.3","qt_arch":"clang_64","host_qt_arch":"","windows_arm64_cross":false,"needs_nsis":false},{"artifact":"windows-x64","os":"windows-2022","preset":"vcpkg-windows-release","package_preset":"vcpkg-windows-installer","qt_version":"6.9.3","qt_arch":"win64_msvc2022_64","host_qt_arch":"","windows_arm64_cross":false,"needs_nsis":true}]}'
-          elif [[ "$package_set" == "full" ]]; then
-            package_matrix='{"include":[{"artifact":"macos-arm64","os":"macos-15","preset":"vcpkg-osx-release","package_preset":"vcpkg-osx-dmg","qt_version":"6.9.3","qt_arch":"clang_64","host_qt_arch":"","windows_arm64_cross":false,"needs_nsis":false},{"artifact":"macos-x64","os":"macos-15-intel","preset":"vcpkg-osx-x64-release","package_preset":"vcpkg-osx-x64-dmg","qt_version":"6.9.3","qt_arch":"clang_64","host_qt_arch":"","windows_arm64_cross":false,"needs_nsis":false},{"artifact":"windows-x64","os":"windows-2022","preset":"vcpkg-windows-release","package_preset":"vcpkg-windows-installer","qt_version":"6.9.3","qt_arch":"win64_msvc2022_64","host_qt_arch":"","windows_arm64_cross":false,"needs_nsis":true},{"artifact":"windows-arm64","os":"windows-2022","preset":"vcpkg-windows-arm64-release","package_preset":"vcpkg-windows-arm64-installer","qt_version":"6.9.3","qt_arch":"win64_msvc2022_arm64_cross_compiled","host_qt_arch":"win64_msvc2022_64","windows_arm64_cross":true,"needs_nsis":true}]}'
-          else
-            echo "::error::package_set must be smoke, standard, or full: $package_set"
-            exit 1
-          fi
+          smoke_matrix="$(jq -c . <<'JSON'
+          {
+            "include": [
+              {
+                "artifact": "macos-x64",
+                "os": "macos-15-intel",
+                "preset": "vcpkg-osx-x64-release",
+                "package_preset": "vcpkg-osx-x64-dmg",
+                "qt_version": "6.9.3",
+                "qt_arch": "clang_64",
+                "host_qt_arch": "",
+                "windows_arm64_cross": false,
+                "needs_nsis": false
+              },
+              {
+                "artifact": "windows-x64",
+                "os": "windows-2022",
+                "preset": "vcpkg-windows-release",
+                "package_preset": "vcpkg-windows-installer",
+                "qt_version": "6.9.3",
+                "qt_arch": "win64_msvc2022_64",
+                "host_qt_arch": "",
+                "windows_arm64_cross": false,
+                "needs_nsis": true
+              }
+            ]
+          }
+          JSON
+          )"
+          release_matrix="$(jq -c . <<'JSON'
+          {
+            "include": [
+              {
+                "artifact": "macos-arm64",
+                "os": "macos-15",
+                "preset": "vcpkg-osx-release",
+                "package_preset": "vcpkg-osx-dmg",
+                "qt_version": "6.9.3",
+                "qt_arch": "clang_64",
+                "host_qt_arch": "",
+                "windows_arm64_cross": false,
+                "needs_nsis": false
+              },
+              {
+                "artifact": "macos-x64",
+                "os": "macos-15-intel",
+                "preset": "vcpkg-osx-x64-release",
+                "package_preset": "vcpkg-osx-x64-dmg",
+                "qt_version": "6.9.3",
+                "qt_arch": "clang_64",
+                "host_qt_arch": "",
+                "windows_arm64_cross": false,
+                "needs_nsis": false
+              },
+              {
+                "artifact": "windows-x64",
+                "os": "windows-2022",
+                "preset": "vcpkg-windows-release",
+                "package_preset": "vcpkg-windows-installer",
+                "qt_version": "6.9.3",
+                "qt_arch": "win64_msvc2022_64",
+                "host_qt_arch": "",
+                "windows_arm64_cross": false,
+                "needs_nsis": true
+              },
+              {
+                "artifact": "windows-arm64",
+                "os": "windows-2022",
+                "preset": "vcpkg-windows-arm64-release",
+                "package_preset": "vcpkg-windows-arm64-installer",
+                "qt_version": "6.9.3",
+                "qt_arch": "win64_msvc2022_arm64_cross_compiled",
+                "host_qt_arch": "win64_msvc2022_64",
+                "windows_arm64_cross": true,
+                "needs_nsis": true
+              }
+            ]
+          }
+          JSON
+          )"
+
+          case "$package_set" in
+            smoke) package_matrix="$smoke_matrix" ;;
+            standard|full) package_matrix="$release_matrix" ;;
+            *)
+              echo "::error::package_set must be smoke, standard, or full: $package_set"
+              exit 1
+              ;;
+          esac
           if [[ "$package_set" == "smoke" && "$publish" == "true" ]]; then
             echo "::error::Smoke package validation cannot publish a GitHub Release. Use package_set=standard or full to publish."
             exit 1
@@ -350,6 +431,7 @@ jobs:
           set -euo pipefail
           python3 scripts/release/generate_changelog.py \
             --tag "${{ needs.preflight.outputs.tag }}" \
+            --audience public \
             --output release-notes.md
 
       - name: Download package artifacts

--- a/docs/development/release-governance.md
+++ b/docs/development/release-governance.md
@@ -127,8 +127,12 @@ Rules:
 
 ## Changelog
 
-Generate changelog entries from Conventional Commits between release tags.
-Automation should group commits as follows:
+Generate changelog entries from Conventional Commits between release tags. Public
+release notes should stay user-oriented: visible feature, fix, performance, and
+breaking-change entries are listed directly, while internal CI, build, test, and
+maintenance work is collapsed into a concise maintenance summary.
+
+Maintainer changelog review can still group commits as follows:
 
 | Commit type | Changelog section |
 | --- | --- |
@@ -148,13 +152,15 @@ Use the deterministic generator for release notes and changelog review:
 
 ```bash
 python scripts/release/generate_changelog.py --from v1.0.0 --to HEAD
+python scripts/release/generate_changelog.py --from v1.0.0 --to HEAD --audience maintainer
 python scripts/release/generate_changelog.py --tag v1.1.0 --output release-notes.md
 ```
 
 `--tag` resolves the previous release tag automatically when `--from` is not
 provided. The generator skips merge commits and `chore(release): vX.Y.Z`
-release-marker commits, keeps section order stable, and includes short commit
-SHAs for traceability.
+release-marker commits, keeps section order stable, and defaults to concise
+public notes. Use `--audience maintainer` when you need the detailed
+commit-by-commit view with short SHAs for traceability.
 
 Use `--check` before tagging when you want to fail on commits that cannot be
 classified by the Conventional Commit rules:
@@ -187,9 +193,10 @@ contract that CI, changelog, and packaging workflows should enforce.
 ## Release Package Sets
 
 - `standard` is the default stable release package set. It publishes the
-  macOS x64 DMG and Windows x64 installer.
-- `smoke` runs the same x64 package lanes without publishing and is intended for
-  manual release workflow validation.
-- `full` adds macOS arm64 and Windows arm64 packages for manual supplemental
-  artifact runs. This is a packaging artifact set, not the CI `matrix=full`
+  macOS arm64 DMG, macOS x64 DMG, Windows x64 installer, and Windows arm64
+  installer.
+- `smoke` runs only the macOS x64 and Windows x64 package lanes without
+  publishing and is intended for manual release workflow validation.
+- `full` is kept as a compatibility alias for the complete four-platform release
+  package set. This is a packaging artifact set, not the CI `matrix=full`
   validation tier.

--- a/scripts/release/generate_changelog.py
+++ b/scripts/release/generate_changelog.py
@@ -37,6 +37,29 @@ SECTIONS = OrderedDict(
     ]
 )
 
+PUBLIC_SECTIONS = OrderedDict(
+    [
+        ("breaking", "Breaking Changes"),
+        ("feat", "Features"),
+        ("fix", "Bug Fixes"),
+        ("perf", "Performance"),
+    ]
+)
+
+INTERNAL_KEYWORDS = (
+    "automation",
+    "build",
+    "changelog",
+    "ci",
+    "cmake",
+    "packag",
+    "release",
+    "smoke",
+    "test",
+    "validation",
+    "workflow",
+)
+
 TYPE_TO_SECTION = {
     "feat": "feat",
     "fix": "fix",
@@ -156,6 +179,66 @@ def format_entry(entry: Entry) -> str:
     return f"- {prefix}{entry.summary} (`{entry.sha[:7]}`)"
 
 
+def format_public_entry(entry: Entry) -> str:
+    prefix = f"{entry.scope}: " if entry.scope else ""
+    return f"- {prefix}{entry.summary}"
+
+
+def is_internal_entry(section_key: str, entry: Entry) -> bool:
+    if section_key in {"build_ci", "docs", "refactor", "test", "maintenance", "other"}:
+        return True
+    text = f"{entry.scope or ''} {entry.summary}".lower()
+    return any(keyword in text for keyword in INTERNAL_KEYWORDS)
+
+
+def join_words(words: list[str]) -> str:
+    if len(words) == 1:
+        return words[0]
+    if len(words) == 2:
+        return f"{words[0]} and {words[1]}"
+    return f"{', '.join(words[:-1])}, and {words[-1]}"
+
+
+def maintenance_entry(areas: set[str]) -> str:
+    ordered_areas: list[str] = []
+    if "release" in areas:
+        ordered_areas.extend(["release packaging", "CI automation"])
+    if "tests" in areas:
+        ordered_areas.append("test coverage")
+    if "docs" in areas:
+        ordered_areas.append("documentation")
+    if "internal" in areas:
+        ordered_areas.append("internal maintenance")
+    if not ordered_areas:
+        ordered_areas.append("project maintenance")
+    return f"- Improved {join_words(ordered_areas)}."
+
+
+def maintenance_area(section_key: str, entry: Entry) -> str:
+    text = f"{entry.scope or ''} {entry.summary}".lower()
+    if section_key == "test" or "test" in text:
+        return "tests"
+    if section_key == "docs":
+        return "docs"
+    if section_key == "build_ci" or any(
+        keyword in text
+        for keyword in (
+            "automation",
+            "build",
+            "changelog",
+            "ci",
+            "cmake",
+            "packag",
+            "release",
+            "smoke",
+            "validation",
+            "workflow",
+        )
+    ):
+        return "release"
+    return "internal"
+
+
 def classify(commits: list[Commit]) -> tuple[OrderedDict[str, list[Entry]], list[Commit]]:
     grouped: OrderedDict[str, list[Entry]] = OrderedDict((key, []) for key in SECTIONS)
     unknown: list[Commit] = []
@@ -193,7 +276,7 @@ def classify(commits: list[Commit]) -> tuple[OrderedDict[str, list[Entry]], list
     return grouped, unknown
 
 
-def render_notes(
+def render_maintainer_notes(
     release_name: str,
     release_date: str,
     from_ref: str | None,
@@ -219,6 +302,51 @@ def render_notes(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def render_public_notes(
+    release_name: str,
+    release_date: str,
+    from_ref: str | None,
+    grouped: OrderedDict[str, list[Entry]],
+) -> str:
+    lines = [f"## {release_name} - {release_date}", ""]
+    if from_ref:
+        lines.extend([f"_Changes since `{from_ref}`._", ""])
+
+    public_grouped: OrderedDict[str, list[Entry]] = OrderedDict(
+        (key, []) for key in PUBLIC_SECTIONS
+    )
+    maintenance_areas: set[str] = set()
+
+    for section_key, entries in grouped.items():
+        for entry in entries:
+            if section_key == "breaking" or (
+                section_key in PUBLIC_SECTIONS
+                and not is_internal_entry(section_key, entry)
+            ):
+                public_grouped[section_key].append(entry)
+            else:
+                maintenance_areas.add(maintenance_area(section_key, entry))
+
+    wrote_section = False
+    for section_key, title in PUBLIC_SECTIONS.items():
+        entries = public_grouped[section_key]
+        if not entries:
+            continue
+        wrote_section = True
+        lines.extend([f"### {title}", ""])
+        lines.extend(format_public_entry(entry) for entry in entries)
+        lines.append("")
+
+    if maintenance_areas:
+        wrote_section = True
+        lines.extend(["### Maintenance", "", maintenance_entry(maintenance_areas), ""])
+
+    if not wrote_section:
+        lines.extend(["No notable changes.", ""])
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate deterministic release notes from Conventional Commits."
@@ -230,6 +358,12 @@ def parse_args() -> argparse.Namespace:
         help="Release tag. Also used as --to, and auto-detects the previous release tag when --from is omitted.",
     )
     parser.add_argument("--output", help="Write release notes to this file.")
+    parser.add_argument(
+        "--audience",
+        choices=("public", "maintainer"),
+        default="public",
+        help="Generate concise public notes or detailed maintainer notes. Defaults to public.",
+    )
     parser.add_argument(
         "--check",
         action="store_true",
@@ -252,7 +386,12 @@ def main() -> int:
     commits = read_commits(from_ref, to_ref)
     grouped, unknown = classify(commits)
     release_name = args.tag or to_ref
-    notes = render_notes(release_name, commit_date(to_ref), from_ref, grouped)
+    if args.audience == "maintainer":
+        notes = render_maintainer_notes(
+            release_name, commit_date(to_ref), from_ref, grouped
+        )
+    else:
+        notes = render_public_notes(release_name, commit_date(to_ref), from_ref, grouped)
 
     if args.output:
         pathlib.Path(args.output).write_text(notes, encoding="utf-8", newline="\n")


### PR DESCRIPTION
﻿## Summary
- make the stable `standard` release package set publish macOS arm64/x64 and Windows x64/arm64 artifacts
- keep `full` as a compatibility alias for the complete four-platform release package set
- make deterministic release notes concise by default, collapsing internal CI/build/test details into a public maintenance summary
- keep `--audience maintainer` for detailed commit-by-commit changelog review with short SHAs

## Validation
- `python -m py_compile scripts/release/generate_changelog.py`
- `python scripts/release/generate_changelog.py --from v1.0.0 --to v1.0.1 --check`
- `python scripts/release/generate_changelog.py --from v1.0.0 --to v1.0.1 --audience maintainer --check`
- `git diff --check`
- Git Bash `bash -n` against the release package matrix shell block

## Merge policy
- merge with rebase only; do not create a merge commit on `main`