### PR TITLE
fix(release): require curated public notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,6 +461,8 @@ jobs:
           python3 scripts/release/generate_changelog.py \
             --tag "${{ needs.preflight.outputs.tag }}" \
             --audience public \
+            --require-curated \
+            --check \
             --output release-notes.md
 
       - name: Download package artifacts

--- a/docs/development/release-governance.md
+++ b/docs/development/release-governance.md
@@ -136,10 +136,16 @@ Rules:
 
 ## Changelog
 
-Generate changelog entries from Conventional Commits between release tags. Public
-release notes should stay user-oriented: visible feature, fix, performance, and
-breaking-change entries are listed directly, while internal CI, build, test, and
-maintenance work is collapsed into a concise maintenance summary.
+Use Conventional Commits between release tags as the auditable maintainer
+changelog. Do not publish that commit list directly as public release notes.
+Public notes need an editorial pass that groups iterative commits into a few
+user-visible outcomes and explains why the release matters.
+
+Store reviewed public notes at `docs/releases/vX.Y.Z.md` before creating the
+tag. Start with a short release theme, then describe capabilities and fixes in
+user language. Avoid commit scopes, implementation-only terminology, repeated
+entries for the same problem, and generic maintenance summaries. Link to the
+full comparison when commit-level detail is useful.
 
 Maintainer changelog review can still group commits as follows:
 
@@ -157,19 +163,25 @@ Maintainer changelog review can still group commits as follows:
 Breaking changes must be called out in a dedicated section even when the project
 is still below `1.0.0`.
 
-Use the deterministic generator for release notes and changelog review:
+Use the generator for both reviewed public notes and maintainer changelog
+review:
 
 ```bash
 python scripts/release/generate_changelog.py --from v1.0.0 --to HEAD
 python scripts/release/generate_changelog.py --from v1.0.0 --to HEAD --audience maintainer
-python scripts/release/generate_changelog.py --tag v1.1.0 --output release-notes.md
+python scripts/release/generate_changelog.py --tag v1.1.0 --require-curated --output release-notes.md
 ```
 
 `--tag` resolves the previous release tag automatically when `--from` is not
-provided. The generator skips merge commits and `chore(release): vX.Y.Z`
-release-marker commits, keeps section order stable, and defaults to concise
-public notes. Use `--audience maintainer` when you need the detailed
-commit-by-commit view with short SHAs for traceability.
+provided. For public output, the generator automatically discovers
+`docs/releases/<tag>.md`. `--require-curated` fails when that reviewed file is
+missing, which is mandatory in the GitHub Release workflow. Without it, the
+script may produce a commit-derived draft for local review, but that draft must
+not be published unchanged.
+
+The generator skips merge commits and `chore(release): vX.Y.Z` release-marker
+commits. Use `--audience maintainer` for the detailed commit-by-commit view with
+stable section ordering and short SHAs for traceability.
 
 Use `--check` before tagging when you want to fail on commits that cannot be
 classified by the Conventional Commit rules:
@@ -196,7 +208,8 @@ Before creating a stable tag:
    If the change touches CMake, tests, Qt compatibility, platform behavior, or
    component input/windowing behavior, include the Ubuntu 22.04 Linux validation
    covered in [Linux Workflow](linux-workflow.md).
-5. Generate or update the changelog from the previous release tag.
+5. Add `docs/releases/vX.Y.Z.md`, preview it with `--require-curated`, and review
+   the maintainer changelog from the previous release tag.
 6. Create an annotated tag.
 7. Build and attach release artifacts.
 8. Publish the GitHub Release notes, installers, and one aggregate

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,42 @@
+Fluent-Qt 1.3.0 brings the library and Gallery to desktop Linux. The focus of
+this release is a coherent Fluent windowing experience across Windows, macOS,
+X11, and Wayland, rather than a collection of isolated component changes.
+
+## Linux support
+
+- Fluent window chrome, title-bar move and resize, same-window dialogs and
+  flyouts, font fallback, and Gallery window lifecycle behavior now work on
+  both X11 and Wayland.
+- Linux is covered on x64 and ARM64, with Qt 5.15 support on x64 and Qt 6.2
+  support on both architectures.
+- Ready-to-install Debian packages are now included in every standard release.
+
+## Windowing and visual consistency
+
+- `Window::setBackdropEffect()` provides one Mica/Acrylic contract across
+  platforms. Fluent-Qt uses native DWM or Cocoa effects where available, KWin
+  blur on supported X11 desktops, and a stable painted material everywhere
+  else.
+- Bundled static Segoe UI optical faces give captions, body text, and headings
+  consistent metrics on systems that do not ship Segoe UI.
+
+## Reliability fixes
+
+- Starting Gallery a second time now restores and activates the existing
+  window instead of opening a duplicate instance.
+- Window dragging, resizing, activation, and restore behavior is more reliable
+  across Windows, X11, and Wayland, including minimized and HiDPI cases.
+- Fixed text-field placeholder rendering and several backdrop, navigation, and
+  overlay repaint artifacts.
+
+## Downloads
+
+| Qt | Windows | macOS | Linux |
+| --- | --- | --- | --- |
+| 5.15 | x64 | x64 | x64 |
+| 6.2 | x64 | x64, ARM64 | x64, ARM64 |
+| 6.9.3 | ARM64 | Not supported | Not supported |
+
+Use `SHA256SUMS.txt` to verify the nine attached installers and packages.
+
+[Compare v1.2.1...v1.3.0](https://github.com/calvinhxx/Fluent-Qt/compare/v1.2.1...v1.3.0)

--- a/scripts/release/generate_changelog.py
+++ b/scripts/release/generate_changelog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate deterministic release notes from Conventional Commits."""
+"""Generate maintainer changelogs and curated public release notes."""
 
 from __future__ import annotations
 
@@ -20,6 +20,10 @@ FOOTER_RE = re.compile(r"^[A-Za-z][A-Za-z-]*: .+")
 RELEASE_COMMIT_RE = re.compile(
     r"^chore(?:\([^)]*\))?: v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?$"
 )
+RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?$")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CURATED_PUBLIC_NOTES_DIR = REPO_ROOT / "docs" / "releases"
 
 SECTIONS = OrderedDict(
     [
@@ -347,9 +351,29 @@ def render_public_notes(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def default_curated_public_notes(tag: str) -> pathlib.Path | None:
+    if not RELEASE_TAG_RE.fullmatch(tag):
+        return None
+    return CURATED_PUBLIC_NOTES_DIR / f"{tag}.md"
+
+
+def read_curated_public_notes(path: pathlib.Path) -> str:
+    try:
+        notes = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RuntimeError(
+            f"Could not read curated public notes at {path}: {error}"
+        ) from error
+
+    notes = notes.strip()
+    if not notes:
+        raise RuntimeError(f"Curated public notes are empty: {path}")
+    return notes + "\n"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate deterministic release notes from Conventional Commits."
+        description="Generate maintainer changelogs and curated public release notes."
     )
     parser.add_argument("--from", dest="from_ref", help="Previous tag or commit.")
     parser.add_argument("--to", dest="to_ref", help="Target tag or commit. Defaults to HEAD.")
@@ -362,7 +386,23 @@ def parse_args() -> argparse.Namespace:
         "--audience",
         choices=("public", "maintainer"),
         default="public",
-        help="Generate concise public notes or detailed maintainer notes. Defaults to public.",
+        help=(
+            "Generate curated public notes when available or a detailed maintainer "
+            "changelog. Defaults to public."
+        ),
+    )
+    parser.add_argument(
+        "--public-notes",
+        metavar="PATH",
+        help=(
+            "Use this reviewed Markdown file for public notes. With --tag, "
+            "docs/releases/<tag>.md is discovered automatically."
+        ),
+    )
+    parser.add_argument(
+        "--require-curated",
+        action="store_true",
+        help="Fail instead of publishing a commit-derived public draft.",
     )
     parser.add_argument(
         "--check",
@@ -373,6 +413,14 @@ def parse_args() -> argparse.Namespace:
 
     if args.tag and args.to_ref:
         parser.error("--tag cannot be combined with --to")
+    if args.audience == "maintainer" and (
+        args.public_notes or args.require_curated
+    ):
+        parser.error(
+            "--public-notes and --require-curated only apply to --audience public"
+        )
+    if args.require_curated and not (args.public_notes or args.tag):
+        parser.error("--require-curated requires --tag or --public-notes")
     return args
 
 
@@ -391,7 +439,40 @@ def main() -> int:
             release_name, commit_date(to_ref), from_ref, grouped
         )
     else:
-        notes = render_public_notes(release_name, commit_date(to_ref), from_ref, grouped)
+        curated_path: pathlib.Path | None = None
+        if args.public_notes:
+            curated_path = pathlib.Path(args.public_notes)
+        elif args.tag:
+            candidate = default_curated_public_notes(args.tag)
+            if candidate and candidate.is_file():
+                curated_path = candidate
+
+        if curated_path:
+            try:
+                notes = read_curated_public_notes(curated_path)
+            except RuntimeError as error:
+                print(f"error: {error}", file=sys.stderr)
+                return 2
+        elif args.require_curated:
+            expected = (
+                default_curated_public_notes(args.tag) if args.tag else None
+            )
+            location = expected or pathlib.Path(args.public_notes or "<unspecified>")
+            print(
+                f"error: Curated public notes are required but were not found: {location}",
+                file=sys.stderr,
+            )
+            return 2
+        else:
+            if args.tag:
+                print(
+                    "warning: No curated public notes were found; generating a "
+                    "commit-derived draft for review.",
+                    file=sys.stderr,
+                )
+            notes = render_public_notes(
+                release_name, commit_date(to_ref), from_ref, grouped
+            )
 
     if args.output:
         pathlib.Path(args.output).write_text(notes, encoding="utf-8", newline="\n")


### PR DESCRIPTION
## What changed

- require reviewed `docs/releases/vX.Y.Z.md` notes for automated GitHub Releases
- keep the commit-derived changelog as a maintainer/audit view instead of publishing it verbatim
- add user-oriented v1.3.0 notes organized around Linux support, portable backdrops, typography, and reliability
- document the editorial and pre-tag review rules

## Why

The previous public renderer only filtered Conventional Commit subjects. That left implementation scopes, repeated fixes, and a generic maintenance sentence in the public release, so the result read like an internal commit list rather than useful product notes.

## Validation

- curated v1.3.0 output matches its reviewed Markdown source exactly
- missing curated notes fail with exit code 2 when `--require-curated` is used
- maintainer changelog still classifies the full v1.2.1..v1.3.0 range with `--check`
- `git diff --check`
