### PR TITLE
chore(release): v1.5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(POLICY CMP0091)
 endif()
 set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
 
-project(FluentQt VERSION 1.5.2 LANGUAGES CXX C)
+project(FluentQt VERSION 1.5.3 LANGUAGES CXX C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ include(FetchContent)
 FetchContent_Declare(
     fluentqt
     GIT_REPOSITORY https://github.com/calvinhxx/Fluent-Qt.git
-    GIT_TAG v1.5.2
+    GIT_TAG v1.5.3
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@ include(FetchContent)
 FetchContent_Declare(
     fluentqt
     GIT_REPOSITORY https://github.com/calvinhxx/Fluent-Qt.git
-    GIT_TAG v1.5.2
+    GIT_TAG v1.5.3
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/docs/releases/v1.5.3.md
+++ b/docs/releases/v1.5.3.md
@@ -1,0 +1,16 @@
+Fluent-Qt 1.5.3 is a focused reliability update for Fluent button feedback and
+native macOS window movement.
+
+## Button rendering
+
+- Pressed Fluent buttons now move only their icon and text content, keeping the
+  painted surface fixed so the bottom border remains visible.
+
+## macOS window movement
+
+- Custom title bars now fall back to AppKit's native window drag when Qt rejects
+  intermittent built-in trackpad pressure or gesture events.
+- The fallback preserves native window-server behavior, including Spaces,
+  instead of moving the widget manually.
+
+[Compare v1.5.2...v1.5.3](https://github.com/calvinhxx/Fluent-Qt/compare/v1.5.2...v1.5.3)

--- a/site/index.html
+++ b/site/index.html
@@ -310,7 +310,7 @@
 FetchContent_Declare(
   fluentqt
   GIT_REPOSITORY <span class="code-string">https://github.com/calvinhxx/Fluent-Qt.git</span>
-  GIT_TAG <span class="code-string">v1.5.2</span>
+  GIT_TAG <span class="code-string">v1.5.3</span>
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/src/compatibility/WindowChromeCompat_mac.cpp
+++ b/src/compatibility/WindowChromeCompat_mac.cpp
@@ -28,6 +28,8 @@ constexpr long NSWindowTitleHidden = 1;
 constexpr unsigned long NSWindowCloseButton = 0;
 constexpr unsigned long NSWindowMiniaturizeButton = 1;
 constexpr unsigned long NSWindowZoomButton = 2;
+constexpr unsigned long NSEventTypeLeftMouseDown = 1;
+constexpr unsigned long NSLeftMouseButtonMask = 1UL << 0;
 
 SEL selector(const char* name) {
     return sel_registerName(name);
@@ -52,6 +54,15 @@ id sendClassId(const char* className, const char* name) {
         return nil;
 
     using Send = id (*)(Class, SEL);
+    return reinterpret_cast<Send>(objc_msgSend)(cls, selector(name));
+}
+
+unsigned long sendClassUnsignedLong(const char* className, const char* name) {
+    Class cls = objc_getClass(className);
+    if (!cls)
+        return 0;
+
+    using Send = unsigned long (*)(Class, SEL);
     return reinterpret_cast<Send>(objc_msgSend)(cls, selector(name));
 }
 
@@ -81,6 +92,11 @@ void sendId(id receiver, const char* name, id value) {
 
 unsigned long sendUnsignedLong(id receiver, const char* name) {
     using Send = unsigned long (*)(id, SEL);
+    return reinterpret_cast<Send>(objc_msgSend)(receiver, selector(name));
+}
+
+long sendLong(id receiver, const char* name) {
+    using Send = long (*)(id, SEL);
     return reinterpret_cast<Send>(objc_msgSend)(receiver, selector(name));
 }
 
@@ -124,6 +140,11 @@ CGRect sendRect(id receiver, const char* name) {
     using Send = CGRect (*)(id, SEL);
     return reinterpret_cast<Send>(objc_msgSend)(receiver, selector(name));
 #endif
+}
+
+CGPoint sendPoint(id receiver, const char* name) {
+    using Send = CGPoint (*)(id, SEL);
+    return reinterpret_cast<Send>(objc_msgSend)(receiver, selector(name));
 }
 
 void sendPoint(id receiver, const char* name, CGPoint value) {
@@ -183,6 +204,45 @@ id nativeWindowFor(QWidget* window) {
         return sendId(nativeObject, "window");
 
     return nil;
+}
+
+id createSystemMoveMouseDownEvent(id nsWindow) {
+    static constexpr const char* MouseEventFactory =
+        "mouseEventWithType:location:modifierFlags:timestamp:windowNumber:context:"
+        "eventNumber:clickCount:pressure:";
+
+    Class eventClass = objc_getClass("NSEvent");
+    if (!eventClass
+        || !respondsTo(reinterpret_cast<id>(eventClass), selector(MouseEventFactory))
+        || !respondsTo(nsWindow, selector("mouseLocationOutsideOfEventStream"))
+        || !respondsTo(nsWindow, selector("windowNumber"))) {
+        return nil;
+    }
+
+    const CGPoint location = sendPoint(nsWindow, "mouseLocationOutsideOfEventStream");
+    const long windowNumber = sendLong(nsWindow, "windowNumber");
+    using Send = id (*)(Class,
+                        SEL,
+                        unsigned long,
+                        CGPoint,
+                        unsigned long,
+                        double,
+                        long,
+                        id,
+                        long,
+                        long,
+                        float);
+    return reinterpret_cast<Send>(objc_msgSend)(eventClass,
+                                                 selector(MouseEventFactory),
+                                                 NSEventTypeLeftMouseDown,
+                                                 location,
+                                                 0UL,
+                                                 0.0,
+                                                 windowNumber,
+                                                 nil,
+                                                 0L,
+                                                 1L,
+                                                 1.0f);
 }
 
 void centerTrafficLights(id nsWindow, const QRect& titleBarRect = QRect()) {
@@ -543,9 +603,32 @@ bool handlePlatformNativeEvent(QWidget* window,
 }
 
 bool beginPlatformSystemMove(QWidget* window, const QPoint& globalPos) {
-    Q_UNUSED(window);
     Q_UNUSED(globalPos);
-    return false;
+    if (!window || QGuiApplication::platformName() != QStringLiteral("cocoa"))
+        return false;
+
+    id nsWindow = nativeWindowFor(window);
+    if (!nsWindow || !respondsTo(nsWindow, selector("performWindowDragWithEvent:")))
+        return false;
+
+    // QTBUG-141220: QCocoaWindow::startSystemMove() rejects intermittent trackpad
+    // pressure/gesture events even though the left button is still down. Hand
+    // AppKit a fresh mouse-down event so native dragging, Spaces, and
+    // window-server behavior remain intact instead of using QWidget::move().
+    // zh_CN: QTBUG-141220 中 QCocoaWindow::startSystemMove() 会间歇性拒绝触控板
+    // pressure/gesture 事件；在左键仍按下时合成 mouse-down 交还 AppKit，保留原生拖动与
+    // Spaces 行为。
+    if ((sendClassUnsignedLong("NSEvent", "pressedMouseButtons")
+         & NSLeftMouseButtonMask) == 0) {
+        return false;
+    }
+
+    id mouseDownEvent = createSystemMoveMouseDownEvent(nsWindow);
+    if (!mouseDownEvent)
+        return false;
+
+    sendId(nsWindow, "performWindowDragWithEvent:", mouseDownEvent);
+    return true;
 }
 
 bool beginPlatformSystemResize(QWidget* window, Qt::Edges edges, const QPoint& globalPos) {

--- a/src/components/basicinput/Button.cpp
+++ b/src/components/basicinput/Button.cpp
@@ -457,23 +457,18 @@ void Button::paintEvent(QPaintEvent*) {
     }
 
     // 3. Paint the background and border. zh_CN: 绘制背景和边框。
-    QRectF contentRect = rect();
+    const QRectF surfaceRect = rect();
     QMargins radii = cornerRadii();
     if (pill) {
         // Stadium shape: radius = half the shorter side. zh_CN: 胶囊形:圆角取较短边的一半。
-        const int r = qRound(qMin(contentRect.width(), contentRect.height()) / 2.0);
+        const int r = qRound(qMin(surfaceRect.width(), surfaceRect.height()) / 2.0);
         radii = QMargins(r, r, r, r);
     }
 
-    // Fluent nudges content down 0.5px while pressed; Material/macOS use color, not motion. zh_CN: Fluent 按下时内容下移 0.5px;M3/macOS 用颜色而非位移。
-    if (state == Pressed && m_style != Subtle && lang == DesignFluent) {
-        contentRect.translate(0, 0.5);
-    }
-
-    const QPainterPath surfacePath = roundedRectPath(contentRect, radii);
+    const QPainterPath surfacePath = roundedRectPath(surfaceRect, radii);
     painter.setPen(Qt::NoPen);
     if (useGradient) {
-        QLinearGradient gradient(contentRect.topLeft(), contentRect.bottomLeft());
+        QLinearGradient gradient(surfaceRect.topLeft(), surfaceRect.bottomLeft());
         gradient.setColorAt(0.0, gradTop);
         gradient.setColorAt(1.0, gradBottom);
         painter.setBrush(gradient);
@@ -498,13 +493,13 @@ void Button::paintEvent(QPaintEvent*) {
         painter.setBrush(Qt::NoBrush);
         QColor shadow(0, 0, 0, darkTheme ? 0x3A : 0x1E); // softer on dark, ~12% on light. zh_CN: 深色更弱,浅色约 12%。
         painter.setPen(QPen(shadow, 1.0));
-        painter.drawPath(roundedRectPath(contentRect.adjusted(0.5, 1.5, -0.5, -0.5), radii));
+        painter.drawPath(roundedRectPath(surfaceRect.adjusted(0.5, 1.5, -0.5, -0.5), radii));
         painter.restore();
     }
 
     if (borderColor != Qt::transparent) {
         const auto borderStroke = fluent::painting::DpiPaintMetrics(painter).alignedStroke(
-            contentRect, 1.0);
+            surfaceRect, 1.0);
         painter.setBrush(Qt::NoBrush);
         painter.setPen(QPen(borderColor, borderStroke.width));
         painter.drawPath(roundedRectPath(borderStroke.rect, radii));
@@ -520,7 +515,7 @@ void Button::paintEvent(QPaintEvent*) {
         painter.setBrush(Qt::NoBrush);
         
         // Restore the 1.5px inset. zh_CN: 恢复为 1.5 像素内缩。
-        painter.drawPath(roundedRectPath(contentRect.adjusted(1.5, 1.5, -1.5, -1.5), adjustedRadii(radii, -1)));
+        painter.drawPath(roundedRectPath(surfaceRect.adjusted(1.5, 1.5, -1.5, -1.5), adjustedRadii(radii, -1)));
     }
 
     // 4. Lay out and paint the icon and text using token gaps. zh_CN: 使用 Token 间距计算并绘制图标和文字。
@@ -549,6 +544,13 @@ void Button::paintEvent(QPaintEvent*) {
     
     int totalContentWidth = txtWidth + iconWidth + ((!txt.isEmpty() && (hasIconFont || !pix.isNull())) ? gap : 0);
     
+    QRectF contentRect = surfaceRect;
+    // Fluent nudges only the icon/text content down while pressed; moving the
+    // surface would clip its bottom border at the widget edge.
+    // zh_CN: Fluent 按下时只下移图标/文字内容；移动表面会使底边框被控件边界裁掉。
+    if (state == Pressed && m_style != Subtle && lang == DesignFluent) {
+        contentRect.translate(0, 0.5);
+    }
     const QRectF layoutRect = contentPaintRect(contentRect);
     double startX = layoutRect.left() + (layoutRect.width() - totalContentWidth) / 2.0;
     double centerY = layoutRect.center().y();

--- a/tests/components/basicinput/TestButton.cpp
+++ b/tests/components/basicinput/TestButton.cpp
@@ -551,6 +551,27 @@ protected:
     }
 };
 
+TEST_F(ButtonDesignLanguageTest, FluentPressedStandardKeepsBottomBorderInsideSurface) {
+    fluent::ThemeRegistry::instance().setDesignLanguage(
+        fluent::FluentElement::DesignFluent);
+    fluent::FluentElement::setTheme(fluent::FluentElement::Light);
+
+    Button button;
+    button.setAttribute(Qt::WA_DontShowOnScreen);
+    button.setFixedSize(96, 32);
+    button.setCornerRadii(QMargins());
+    button.setInteractionState(Button::Pressed);
+
+    const QImage image = renderButtonToImage(button);
+    ASSERT_FALSE(image.isNull());
+
+    const int centerX = image.width() / 2;
+    const QColor interior = image.pixelColor(centerX, image.height() / 2);
+    const QColor bottomBorder = image.pixelColor(centerX, image.height() - 1);
+
+    EXPECT_GT(bottomBorder.alpha(), interior.alpha());
+}
+
 TEST_F(ButtonDesignLanguageTest, EveryLanguageThemeStyleRendersWithoutCrashing) {
     struct LangCase { fluent::FluentElement::DesignLanguage lang; const char* name; };
     struct ThemeCase { fluent::FluentElement::Theme theme; const char* name; };

--- a/tests/components/windowing/TestWindow.cpp
+++ b/tests/components/windowing/TestWindow.cpp
@@ -287,7 +287,10 @@ QWidget* createWindowContent() {
     contentLayout->addWidget(heading);
 
     auto* body = new Label(
-        "On macOS, native traffic lights stay on the left. On Windows, the caption buttons are drawn by Qt while DWM still provides resize, Snap, shadow, and maximize geometry.",
+        "On macOS, native traffic lights stay on the left; repeatedly drag the empty "
+        "title-bar area with the built-in trackpad to verify native system movement. "
+        "On Windows, the caption buttons are drawn by Qt while DWM still provides "
+        "resize, Snap, shadow, and maximize geometry.",
         content);
     body->setFluentTypography(Typography::FontRole::Body);
     body->setWordWrap(true);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "fluent-qt",
-  "version-string": "1.5.2",
+  "version-string": "1.5.3",
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "dependencies": [],
   "features": {


### PR DESCRIPTION
## What changed

- preserve the Fluent button border while its content shifts in the pressed state
- add a native AppKit fallback for intermittent built-in trackpad window-drag failures on macOS
- align project metadata at 1.5.3 and add curated release notes

## Why

The button surface was translated with its content, clipping the bottom border. On macOS, Qt can reject intermittent pressure or gesture events from the built-in trackpad even while the primary button remains pressed.

## Impact

Fluent button feedback keeps a complete border, and custom title bars retain reliable native window movement and Spaces behavior on macOS.

## Validation

- project metadata validation
- 9-scenario standard package-matrix validation
- maintainer changelog validation from v1.5.2
- macOS arm64: test_button + test_window (58/58)
- macOS x64: test_button + test_window (58/58)
- full Release ready CI dispatched on release/1.5.x