### PR TITLE
chore(release): v1.6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(POLICY CMP0091)
 endif()
 set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
 
-project(FluentQt VERSION 1.6.1 LANGUAGES CXX C)
+project(FluentQt VERSION 1.6.2 LANGUAGES CXX C)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ include(FetchContent)
 FetchContent_Declare(
     fluentqt
     GIT_REPOSITORY https://github.com/calvinhxx/Fluent-Qt.git
-    GIT_TAG v1.6.1
+    GIT_TAG v1.6.2
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/readme/hero.png" alt="Fluent-Qt Gallery preview">
+  <a href="https://calvinhxx.github.io/Fluent-Qt/#top"><img src="docs/assets/readme/hero.png" alt="Fluent-Qt Gallery preview"></a>
+</p>
+
+<p align="center">
+  <strong><a href="https://calvinhxx.github.io/Fluent-Qt/#gallery">Try the live C++ Web Gallery</a></strong>
+  ·
+  <a href="https://calvinhxx.github.io/Fluent-Qt/#top">Project website</a>
 </p>
 
 ## 🧱 Dependencies
@@ -216,8 +222,7 @@ cmake --build build/fluentqt --target fluent_qt_source_package
 
 ### WebAssembly
 
-Activate Emscripten 3.1.70 and point the public preset at the matching Qt target
-and host kits:
+Build the WebAssembly Gallery with Qt 6.9.3 `wasm_singlethread` and Emscripten 3.1.70:
 
 ```bash
 source "$HOME/Qt/Tools/emsdk/emsdk_env.sh"
@@ -228,15 +233,7 @@ cmake --build --preset wasm --parallel
 python3 -m http.server 4173 --bind 127.0.0.1 --directory build/wasm
 ```
 
-Open `http://127.0.0.1:4173/app/index.html`. See the
-[WebAssembly workflow](docs/development/webassembly-workflow.md) for browser
-smoke, Asyncify, platform boundaries, CI, deployment, and licensing. The preset
-enables the optional `FluentQt::WebAssembly` runtime, which hosts movable and
-resizable Fluent windows inside one Qt browser desktop; normal native targets
-remain independent.
-High-density displays use an adaptive 1x–1.25x render profile that bounds the
-browser backing-store pixel count; the Gallery footer exposes balanced and
-native-resolution choices when needed.
+Open `http://127.0.0.1:4173/app/index.html`. See the [WebAssembly workflow](docs/development/webassembly-workflow.md) for setup, testing, CI, deployment, and platform notes.
 
 ## 🖼 Gallery
 
@@ -244,9 +241,7 @@ Gallery is used to browse, demonstrate, and validate FluentQt components.
 
 ### C++ Web Gallery
 
-The Qt 6.9.3 single-threaded browser build is published at the
-[C++ Web Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/). It is a
-separate WebAssembly channel; desktop installers remain on GitHub Releases.
+Online: [project website](https://calvinhxx.github.io/Fluent-Qt/#gallery) · [standalone page](https://calvinhxx.github.io/Fluent-Qt/gallery/).
 
 ### C++ Gallery packages
 
@@ -303,8 +298,7 @@ python -m fluentqt_gallery
 - [Release governance](docs/development/release-governance.md)
 - [Architecture contracts](docs/architecture/README.md)
 - [Design language references](docs/design-languages/README.md)
-- [WebAssembly workflow](docs/development/webassembly-workflow.md)
-- [WebAssembly roadmap](docs/development/webassembly-roadmap.md)
+- [WebAssembly compatibility](docs/development/webassembly-workflow.md)
 - [Python compatibility](bindings/pyside6/README.md)
 
 ## 🔗 References

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,13 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/readme/hero.png" alt="Fluent-Qt Gallery 预览">
+  <a href="https://calvinhxx.github.io/Fluent-Qt/#top"><img src="docs/assets/readme/hero.png" alt="Fluent-Qt Gallery 预览"></a>
+</p>
+
+<p align="center">
+  <strong><a href="https://calvinhxx.github.io/Fluent-Qt/#gallery">实时体验 C++ Web Gallery</a></strong>
+  ·
+  <a href="https://calvinhxx.github.io/Fluent-Qt/#top">项目官网</a>
 </p>
 
 ## 🧱 依赖
@@ -215,7 +221,7 @@ cmake --build build/fluentqt --target fluent_qt_source_package
 
 ### WebAssembly
 
-激活 Emscripten 3.1.70，并让公共 preset 指向匹配的 Qt 目标 kit 与宿主 kit：
+使用 Qt 6.9.3 `wasm_singlethread` 和 Emscripten 3.1.70 构建 WebAssembly Gallery：
 
 ```bash
 source "$HOME/Qt/Tools/emsdk/emsdk_env.sh"
@@ -226,12 +232,7 @@ cmake --build --preset wasm --parallel
 python3 -m http.server 4173 --bind 127.0.0.1 --directory build/wasm
 ```
 
-打开 `http://127.0.0.1:4173/app/index.html`。浏览器 smoke、Asyncify、平台边界、
-CI、部署与许可证说明见 [WebAssembly 工作流](docs/development/webassembly-workflow.md)。
-该 preset 会启用可选的 `FluentQt::WebAssembly` 运行时，在单一 Qt 浏览器桌面
-中承载可移动、可缩放的 Fluent 窗口；普通原生目标保持独立。
-高分屏默认使用自适应 1x–1.25x 渲染档位，限制浏览器 backing store 的像素量；
-需要时可通过 Gallery 页脚切换平衡或原生分辨率。
+浏览器打开 `http://127.0.0.1:4173/app/index.html`。环境配置、测试、CI、部署和平台限制见 [WebAssembly 工作流](docs/development/webassembly-workflow.md)。
 
 ## 🖼 Gallery
 
@@ -239,9 +240,7 @@ Gallery 用于浏览、演示和验证 FluentQt 组件。
 
 ### C++ Web Gallery
 
-Qt 6.9.3 单线程浏览器版本发布在
-[C++ Web Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/)。这是独立的
-WebAssembly 渠道；桌面安装包仍通过 GitHub Releases 分发。
+在线体验：[项目官网](https://calvinhxx.github.io/Fluent-Qt/#gallery) · [独立页面](https://calvinhxx.github.io/Fluent-Qt/gallery/)。
 
 ### C++ Gallery 安装包
 
@@ -297,8 +296,7 @@ python -m fluentqt_gallery
 - [发布治理](docs/development/release-governance.md)
 - [架构约定](docs/architecture/README.md)
 - [设计语言参考](docs/design-languages/README.md)
-- [WebAssembly 工作流](docs/development/webassembly-workflow.md)
-- [WebAssembly Roadmap（唯一状态源）](docs/development/webassembly-roadmap.md)
+- [WebAssembly 兼容](docs/development/webassembly-workflow.md)
 - [Python 兼容](bindings/pyside6/README.md)
 
 ## 🔗 参考

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,7 +66,7 @@ include(FetchContent)
 FetchContent_Declare(
     fluentqt
     GIT_REPOSITORY https://github.com/calvinhxx/Fluent-Qt.git
-    GIT_TAG v1.6.1
+    GIT_TAG v1.6.2
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/app/platform/GalleryPlatform.h
+++ b/app/platform/GalleryPlatform.h
@@ -1,14 +1,25 @@
 #ifndef FLUENTQT_GALLERY_PLATFORM_H
 #define FLUENTQT_GALLERY_PLATFORM_H
 
+#include <functional>
+
 #include <QString>
 #include <QUrl>
 
+class QObject;
 class QSettings;
 class QRect;
 class QWidget;
 
 namespace fluent::gallery::platform {
+
+enum class HostTheme {
+    System,
+    Light,
+    Dark
+};
+
+using HostThemeChangedHandler = std::function<void(HostTheme)>;
 
 /**
  * @brief Capabilities supplied by the selected Gallery runtime adapter.
@@ -21,6 +32,12 @@ struct Capabilities {
     bool editsThemeFiles = true;
     bool prewarmsRoutes = true;
     bool usesClientSideTitleBar = false;
+    bool hostControlsTheme = false;
+
+    // Browser visitors enter through an explanatory website and should land
+    // directly in the catalog; desktop packages keep the first-run tour.
+    // zh_CN: 浏览器访客已由官网引导，应直接进入目录；桌面安装包保留首启引导。
+    bool showsIntroTour = true;
 
     // Zero keeps every visited page resident. Browser adapters can cap the
     // cache so a long single-threaded session does not retain every live demo.
@@ -41,6 +58,9 @@ struct Capabilities {
 const Capabilities& capabilities();
 bool persistenceAvailable();
 QSettings createSettings();
+HostTheme hostTheme();
+void setHostThemeChangedHandler(QObject* context,
+                                HostThemeChangedHandler handler);
 void showTopLevelWindow(QWidget* window,
                         const QRect& normalGeometry,
                         bool maximized = false);

--- a/app/platform/desktop/GalleryPlatform.cpp
+++ b/app/platform/desktop/GalleryPlatform.cpp
@@ -40,6 +40,18 @@ QSettings createSettings()
     return QSettings(path, QSettings::IniFormat);
 }
 
+HostTheme hostTheme()
+{
+    return HostTheme::System;
+}
+
+void setHostThemeChangedHandler(QObject* context,
+                                HostThemeChangedHandler handler)
+{
+    Q_UNUSED(context);
+    Q_UNUSED(handler);
+}
+
 void showTopLevelWindow(QWidget* window,
                         const QRect& normalGeometry,
                         bool maximized)

--- a/app/platform/wasm/GalleryPlatform.cpp
+++ b/app/platform/wasm/GalleryPlatform.cpp
@@ -3,10 +3,43 @@
 #include <FluentQt/WebAssembly.h>
 
 #include <QCoreApplication>
+#include <QObject>
+#include <QPointer>
 #include <QRect>
 #include <QSettings>
 
+#include <emscripten.h>
+
+#include <utility>
+
 namespace fluent::gallery::platform {
+namespace {
+
+QPointer<QObject> hostThemeContext;
+HostThemeChangedHandler hostThemeChangedHandler;
+
+EM_JS(int, fluentQtGalleryEmbeddedHost, (), {
+    return window.fluentQtEmbedded === true ? 1 : 0;
+});
+
+EM_JS(int, fluentQtGalleryHostTheme, (), {
+    if (window.fluentQtHostTheme === 'dark')
+        return 2;
+    if (window.fluentQtHostTheme === 'light')
+        return 1;
+    return 0;
+});
+
+HostTheme normalizedHostTheme(int value)
+{
+    if (value == 2)
+        return HostTheme::Dark;
+    if (value == 1)
+        return HostTheme::Light;
+    return HostTheme::System;
+}
+
+} // namespace
 
 const Capabilities& capabilities()
 {
@@ -18,6 +51,8 @@ const Capabilities& capabilities()
         result.editsThemeFiles = false;
         result.prewarmsRoutes = false;
         result.usesClientSideTitleBar = true;
+        result.hostControlsTheme = fluentQtGalleryEmbeddedHost() != 0;
+        result.showsIntroTour = false;
         result.maxResidentRoutes = 16;
         result.applicationName = QStringLiteral("Fluent-Qt C++ Web Gallery");
         result.windowTitle = result.applicationName;
@@ -46,6 +81,31 @@ QSettings createSettings()
                      QSettings::UserScope,
                      QCoreApplication::organizationName(),
                      QCoreApplication::applicationName());
+}
+
+HostTheme hostTheme()
+{
+    if (!capabilities().hostControlsTheme)
+        return HostTheme::System;
+    return normalizedHostTheme(fluentQtGalleryHostTheme());
+}
+
+void setHostThemeChangedHandler(QObject* context,
+                                HostThemeChangedHandler handler)
+{
+    hostThemeContext = context;
+    hostThemeChangedHandler = std::move(handler);
+}
+
+extern "C" EMSCRIPTEN_KEEPALIVE
+void fluentQtGalleryApplyHostTheme(int value)
+{
+    const HostTheme next = normalizedHostTheme(value);
+    if (next == HostTheme::System || !hostThemeContext
+        || !hostThemeChangedHandler) {
+        return;
+    }
+    hostThemeChangedHandler(next);
 }
 
 void showTopLevelWindow(QWidget* window,

--- a/app/platform/wasm/WasmSmokeRunner.cpp
+++ b/app/platform/wasm/WasmSmokeRunner.cpp
@@ -10,6 +10,7 @@
 #include <QFont>
 #include <QFontDatabase>
 #include <QFontMetrics>
+#include <QRegion>
 #include <QSettings>
 #include <QTimer>
 #include <QUrlQuery>
@@ -297,18 +298,27 @@ private:
                     && !actionRect.isEmpty()
                     && menu->rect().contains(actionRect.center());
             }
+            const QRegion surfaceMask = menu->mask();
+            const bool roundedMaskValid = !surfaceMask.isEmpty()
+                && !surfaceMask.contains(menu->rect().topLeft())
+                && !surfaceMask.contains(menu->rect().topRight())
+                && !surfaceMask.contains(menu->rect().bottomRight())
+                && !surfaceMask.contains(menu->rect().bottomLeft())
+                && surfaceMask.contains(menu->rect().center());
             if (!menu->isVisible()
                 || menu->testAttribute(Qt::WA_TranslucentBackground)
-                || !actionGeometryValid) {
+                || !actionGeometryValid
+                || !roundedMaskValid) {
                 menu->close();
                 fail(QStringLiteral(
                     "Opaque browser menu surface/geometry check failed "
-                    "size=%1x%2 hint=%3x%4 geometry=%5")
+                    "size=%1x%2 hint=%3x%4 geometry=%5 roundedMask=%6")
                          .arg(menu->width())
                          .arg(menu->height())
                          .arg(menu->sizeHint().width())
                          .arg(menu->sizeHint().height())
-                         .arg(geometrySummary.join(QLatin1Char('|'))));
+                         .arg(geometrySummary.join(QLatin1Char('|')))
+                         .arg(roundedMaskValid));
                 return;
             }
             QTimer::singleShot(25, menu, &QMenu::close);

--- a/app/platform/wasm/index.html.in
+++ b/app/platform/wasm/index.html.in
@@ -7,6 +7,21 @@
   <title>Fluent-Qt C++ Web Gallery</title>
   <script>
     document.documentElement.dataset.fluentQtLoadStartedAt = String(Date.now());
+    window.fluentQtEmbedded = (() => {
+      const embedded = new URLSearchParams(window.location.search).get('embed') === 'site';
+      document.documentElement.dataset.fluentQtEmbedded = String(embedded);
+      return embedded;
+    })();
+    window.fluentQtHostTheme = (() => {
+      const requested = new URLSearchParams(window.location.search).get('host-theme');
+      window.fluentQtHostThemeFollowsSystem = requested !== 'dark' && requested !== 'light';
+      const theme = requested === 'dark' || requested === 'light'
+        ? requested
+        : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.dataset.fluentQtTheme = theme;
+      document.documentElement.style.colorScheme = theme;
+      return theme;
+    })();
     // Qt 6.9's WebAssembly platform reads window.devicePixelRatio directly
     // when sizing the QWidget backing store. Cap it before qtloader starts so
     // Retina displays do not turn a 1280x720 Gallery into a 2560x1440 paint
@@ -70,6 +85,8 @@
     * { box-sizing: border-box; }
     html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
     body { display: grid; grid-template-rows: minmax(0, 1fr) auto; background: #e9edf3; }
+    html[data-fluent-qt-embedded="true"] body { grid-template-rows: minmax(0, 1fr); }
+    html[data-fluent-qt-embedded="true"] footer { display: none; }
     #qt-container { position: relative; min-width: 0; min-height: 0; overflow: hidden;
       background:
         radial-gradient(circle at 18% 8%, rgb(0 103 192 / 10%), transparent 34%),
@@ -94,15 +111,21 @@
       footer { align-items: flex-start; flex-direction: column; gap: 2px; }
       footer nav { flex-wrap: wrap; }
     }
-    @media (prefers-color-scheme: dark) {
-      body, #loading { background: #202020; color: #f5f5f5; }
-      #qt-container { background:
-        radial-gradient(circle at 18% 8%, rgb(96 205 255 / 10%), transparent 34%),
-        radial-gradient(circle at 82% 92%, rgb(139 92 246 / 10%), transparent 38%),
-        #20242a; }
-      footer { color: #c7c7c7; background: #181818; border-color: #3b3b3b; }
-      footer a { color: #60cdff; }
+    html[data-fluent-qt-theme="dark"] body,
+    html[data-fluent-qt-theme="dark"] #loading {
+      background: #202020;
+      color: #f5f5f5;
     }
+    html[data-fluent-qt-theme="dark"] #qt-container { background:
+      radial-gradient(circle at 18% 8%, rgb(96 205 255 / 10%), transparent 34%),
+      radial-gradient(circle at 82% 92%, rgb(139 92 246 / 10%), transparent 38%),
+      #20242a; }
+    html[data-fluent-qt-theme="dark"] footer {
+      color: #c7c7c7;
+      background: #181818;
+      border-color: #3b3b3b;
+    }
+    html[data-fluent-qt-theme="dark"] footer a { color: #60cdff; }
     @keyframes spin { to { transform: rotate(360deg); } }
   </style>
   <link rel="preload" href="fluent_qt_gallery.wasm" as="fetch"
@@ -137,6 +160,42 @@
     const renderScaleStatus = document.getElementById('render-scale-status');
     const renderScaleToggle = document.getElementById('render-scale-toggle');
     const renderProfile = window.fluentQtRenderProfile;
+    let wasmInstance = null;
+    const normalizeHostTheme = theme => theme === 'dark' ? 'dark' : 'light';
+    const applyHostTheme = theme => {
+      const normalized = normalizeHostTheme(theme);
+      window.fluentQtHostTheme = normalized;
+      document.documentElement.dataset.fluentQtTheme = normalized;
+      document.documentElement.style.colorScheme = normalized;
+      const applyToGallery = wasmInstance?._fluentQtGalleryApplyHostTheme;
+      if (typeof applyToGallery === 'function')
+        applyToGallery(normalized === 'dark' ? 2 : 1);
+    };
+    window.addEventListener('message', event => {
+      if (!window.fluentQtEmbedded || event.source !== window.parent
+          || event.origin !== window.location.origin
+          || event.data?.source !== 'fluent-qt-site'
+          || event.data?.type !== 'theme') {
+        return;
+      }
+      applyHostTheme(event.data.theme);
+    });
+    if (!window.fluentQtEmbedded && window.fluentQtHostThemeFollowsSystem) {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+      const syncSystemTheme = event => applyHostTheme(event.matches ? 'dark' : 'light');
+      if (typeof systemTheme.addEventListener === 'function')
+        systemTheme.addEventListener('change', syncSystemTheme);
+      else
+        systemTheme.addListener(syncSystemTheme);
+    }
+    const notifyHost = (state, detail = {}) => {
+      if (!window.fluentQtEmbedded || window.parent === window) return;
+      window.parent.postMessage({
+        source: 'fluent-qt-gallery',
+        state,
+        detail
+      }, window.location.origin);
+    };
     const formatScale = value => Number(value).toFixed(2).replace(/\.?0+$/, '');
     const profileLabel = renderProfile.profile === 'adaptive' ? 'adaptive ' : '';
     const softOneX = renderProfile.nativeDpr > 1
@@ -171,31 +230,36 @@
       }
       windowModeToggle.href = `${nextWindowUrl.pathname}${nextWindowUrl.search}${nextWindowUrl.hash}`;
     };
+    notifyHost('loading', { phase: 'runtime' });
     (async () => {
       try {
-        await qtLoad({
+        wasmInstance = await qtLoad({
           qt: {
             entryFunction: window.fluent_qt_gallery_entry,
             containerElements: [container],
             onLoaded: () => {
+              const loadMs = Date.now() - Number(
+                document.documentElement.dataset.fluentQtLoadStartedAt);
               document.documentElement.dataset.fluentQtLoaded = 'true';
-              document.documentElement.dataset.fluentQtLoadMs = String(
-                Date.now() - Number(
-                  document.documentElement.dataset.fluentQtLoadStartedAt));
+              document.documentElement.dataset.fluentQtLoadMs = String(loadMs);
               syncWindowMode();
               loading.classList.add('hidden');
+              notifyHost('ready', { loadMs });
               window.setTimeout(() => loading.remove(), 220);
             },
             onExit: exit => {
               document.documentElement.dataset.fluentQtExit = String(exit?.code ?? 'unknown');
+              notifyHost('exit', { code: exit?.code ?? 'unknown' });
             }
           }
         });
+        applyHostTheme(window.fluentQtHostTheme);
       } catch (error) {
         console.error(error);
         document.documentElement.dataset.fluentQtError = String(error);
         loading.classList.add('error');
         detail.textContent = `Could not start WebAssembly: ${error}`;
+        notifyHost('error', { message: String(error) });
       }
     })();
   </script>

--- a/app/view/pages/SettingsPage.cpp
+++ b/app/view/pages/SettingsPage.cpp
@@ -202,10 +202,16 @@ SettingsPage::SettingsPage(const GalleryNavigationItem& item, QWidget* parent)
     m_contentLayout->addSpacing(16);
 
     auto* settings = &GallerySettings::instance();
+    const auto& runtime = platform::capabilities();
     m_themeChoice = createChoiceBox(
         QStringLiteral("gallerySettingsThemeChoice"),
         {QStringLiteral("Use system setting"), QStringLiteral("Light"), QStringLiteral("Dark")},
         static_cast<int>(settings->themeMode()));
+    if (runtime.hostControlsTheme) {
+        m_themeChoice->setEnabled(false);
+        m_themeChoice->setToolTip(
+            QStringLiteral("The embedded Gallery follows the website theme"));
+    }
     // Brand style theme: swaps the whole palette + corner-radius preset at runtime via ThemeRegistry.
     // zh_CN: 品牌样式主题:经 ThemeRegistry 在运行时整体替换调色板 + 圆角预设。
     m_styleChoice = createChoiceBox(
@@ -229,7 +235,6 @@ SettingsPage::SettingsPage(const GalleryNavigationItem& item, QWidget* parent)
         QStringLiteral("gallerySettingsEffectChoice"),
         {QStringLiteral("Normal"), QStringLiteral("Mica"), QStringLiteral("Acrylic")},
         static_cast<int>(settings->windowEffect()));
-    const auto& runtime = platform::capabilities();
     if (runtime.exposesCloseBehavior) {
         m_closeBehaviorChoice = createChoiceBox(
             QStringLiteral("gallerySettingsCloseBehaviorChoice"),
@@ -313,7 +318,9 @@ SettingsPage::SettingsPage(const GalleryNavigationItem& item, QWidget* parent)
     // zh_CN: 应用主题改用「亮度」字形,不再与样式行的调色板图标重复。
     m_contentLayout->addWidget(createSettingsRow(Typography::Icons::Brightness,
                                                  QStringLiteral("App theme"),
-                                                 QStringLiteral("Select which app theme to display"),
+                                                 runtime.hostControlsTheme
+                                                     ? QStringLiteral("Follows the website theme while embedded")
+                                                     : QStringLiteral("Select which app theme to display"),
                                                  m_themeChoice));
     m_contentLayout->addWidget(createSettingsRow(Typography::Icons::Brush,
                                                  QStringLiteral("Style & accent color"),

--- a/app/view/shell/GalleryNavigationDelegate.cpp
+++ b/app/view/shell/GalleryNavigationDelegate.cpp
@@ -13,6 +13,7 @@
 
 #include "components/collections/TreeView.h"
 #include "components/foundation/FluentElement.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 #include "design/Typography.h"
 #include "GalleryNavigationMetrics.h"
 #include "model/GalleryNavigationItem.h"
@@ -226,16 +227,21 @@ public:
         const qreal textRight = hasChildren && !compact
             ? chevronRect.left() - kTextRightGap
             : backgroundRect.right() - kTextRightGap;
-        const QRectF textRect(textX - 6.0 * compactProgress,
+        const QRectF textSlot(textX - 6.0 * compactProgress,
                               backgroundRect.top(),
                               qMax<qreal>(0.0, textRight - textX),
                               backgroundRect.height());
         if (expandedOpacity > 0.01) {
+            const QFontMetricsF metrics(painter->font());
+            const QString elidedText = cachedElidedText(
+                painter->fontMetrics(), text, qRound(textSlot.width()));
+            const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+                textSlot, metrics, elidedText);
             painter->save();
             painter->setOpacity(expandedOpacity);
             painter->drawText(textRect,
                               Qt::AlignLeft | Qt::AlignVCenter,
-                              cachedElidedText(painter->fontMetrics(), text, qRound(textRect.width())));
+                              elidedText);
             painter->restore();
         }
         painter->restore();

--- a/app/view/shell/GalleryNavigationDelegate.cpp
+++ b/app/view/shell/GalleryNavigationDelegate.cpp
@@ -13,7 +13,7 @@
 
 #include "components/collections/TreeView.h"
 #include "components/foundation/FluentElement.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 #include "design/Typography.h"
 #include "GalleryNavigationMetrics.h"
 #include "model/GalleryNavigationItem.h"

--- a/app/view/shell/GalleryWindow.cpp
+++ b/app/view/shell/GalleryWindow.cpp
@@ -327,7 +327,8 @@ void GalleryWindow::finishStartup()
         m_splashScreen->dismiss();  // fades out, then self-deletes
 
     // First launch only: once the chrome has settled, run the intro tour. zh_CN: 仅首次启动：chrome 稳定后跑引导。
-    if (!GallerySettings::instance().introCompleted())
+    if (platform::capabilities().showsIntroTour
+        && !GallerySettings::instance().introCompleted())
         QTimer::singleShot(kIntroTourDelayMs, this, [this]() { maybeStartIntroTour(); });
 }
 

--- a/app/view/widgets/samples/CollectionSampleDelegates.cpp
+++ b/app/view/widgets/samples/CollectionSampleDelegates.cpp
@@ -18,7 +18,7 @@
 #include "components/collections/ListView.h"
 #include "components/collections/TreeView.h"
 #include "components/foundation/FluentElement.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 #include "design/CornerRadius.h"
 #include "design/Spacing.h"
 #include "design/Typography.h"

--- a/app/view/widgets/samples/CollectionSampleDelegates.cpp
+++ b/app/view/widgets/samples/CollectionSampleDelegates.cpp
@@ -18,6 +18,7 @@
 #include "components/collections/ListView.h"
 #include "components/collections/TreeView.h"
 #include "components/foundation/FluentElement.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 #include "design/CornerRadius.h"
 #include "design/Spacing.h"
 #include "design/Typography.h"
@@ -404,7 +405,7 @@ void ListRowDelegate::paint(QPainter* painter, const QStyleOptionViewItem& optio
     }
 
     const QString text = index.data(Qt::DisplayRole).toString();
-    const QRectF textRect(cursorX, bgRect.top(), bgRect.right() - cursorX - 8.0, bgRect.height());
+    const QRectF textSlot(cursorX, bgRect.top(), bgRect.right() - cursorX - 8.0, bgRect.height());
     // macOS solid-accent selection flips the row text to textOnAccent so it stays legible. zh_CN: macOS 纯强调色选中时,行文字翻转为 textOnAccent 以保证可读。
     QColor rowTextColor = isEnabled ? colors.textPrimary : colors.textDisabled;
     if (isEnabled && fill.textOnAccent && colors.textOnAccent.isValid())
@@ -414,8 +415,13 @@ void ListRowDelegate::paint(QPainter* painter, const QStyleOptionViewItem& optio
     if (isSelected)
         font.setWeight(QFont::DemiBold);
     painter->setFont(font);
+    const QFontMetricsF metrics(painter->font());
+    const QString elidedText = metrics.elidedText(
+        text, Qt::ElideRight, qRound(textSlot.width()));
+    const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+        textSlot, metrics, elidedText);
     painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter,
-                      painter->fontMetrics().elidedText(text, Qt::ElideRight, int(textRect.width())));
+                      elidedText);
 
     painter->restore();
 }
@@ -663,7 +669,7 @@ void TreeRowDelegate::paint(QPainter* painter, const QStyleOptionViewItem& optio
     }
 
     // Text.
-    const QRectF textRect = rtl
+    const QRectF textSlot = rtl
         ? QRectF(bgRect.left() + 8.0, bgRect.top(),
                  qMax<qreal>(0.0, cursorX - bgRect.left() - 8.0), bgRect.height())
         : QRectF(cursorX, bgRect.top(),
@@ -671,11 +677,14 @@ void TreeRowDelegate::paint(QPainter* painter, const QStyleOptionViewItem& optio
     painter->setPen(textColor);
     painter->setFont(option.font);
     const QString text = index.data(Qt::DisplayRole).toString();
+    const QFontMetricsF metrics(painter->font());
+    const QString elidedText = metrics.elidedText(
+        text, rtl ? Qt::ElideLeft : Qt::ElideRight, qRound(textSlot.width()));
+    const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+        textSlot, metrics, elidedText);
     painter->drawText(textRect,
                       (rtl ? Qt::AlignRight : Qt::AlignLeft) | Qt::AlignVCenter,
-                      painter->fontMetrics().elidedText(
-                          text, rtl ? Qt::ElideLeft : Qt::ElideRight,
-                          int(textRect.width())));
+                      elidedText);
 
     painter->restore();
 }

--- a/app/view/widgets/samples/CollectionsSamples.cpp
+++ b/app/view/widgets/samples/CollectionsSamples.cpp
@@ -34,6 +34,7 @@
 #include "components/collections/SplitView.h"
 #include "components/collections/StackView.h"
 #include "components/collections/TreeView.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 #include "components/foundation/overlay/OverlayGeometry.h"
 #include "components/textfields/Label.h"
 #include "design/CornerRadius.h"
@@ -412,13 +413,18 @@ protected:
                                               : Typography::FontRole::Body).toQFont();
         painter.setFont(textFont);
         painter.setPen(isEnabled() ? colors.textPrimary : colors.textDisabled);
-        const QRectF textRect(iconRect.right() + 14.0,
+        const QRectF textSlot(iconRect.right() + 14.0,
                               rowRect.top(),
                               rowRect.right() - iconRect.right() - 22.0,
                               rowRect.height());
+        const QFontMetricsF metrics(painter.font());
+        const QString elidedText = metrics.elidedText(
+            m_text, Qt::ElideRight, qRound(textSlot.width()));
+        const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+            textSlot, metrics, elidedText);
         painter.drawText(textRect,
                          Qt::AlignLeft | Qt::AlignVCenter,
-                         painter.fontMetrics().elidedText(m_text, Qt::ElideRight, qRound(textRect.width())));
+                         elidedText);
     }
 
 private:

--- a/app/view/widgets/samples/CollectionsSamples.cpp
+++ b/app/view/widgets/samples/CollectionsSamples.cpp
@@ -34,7 +34,7 @@
 #include "components/collections/SplitView.h"
 #include "components/collections/StackView.h"
 #include "components/collections/TreeView.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 #include "components/foundation/overlay/OverlayGeometry.h"
 #include "components/textfields/Label.h"
 #include "design/CornerRadius.h"

--- a/app/viewmodel/GallerySettings.cpp
+++ b/app/viewmodel/GallerySettings.cpp
@@ -65,6 +65,15 @@ fluent::FluentElement::Theme systemTheme()
     return fluent::FluentElement::Light;
 }
 
+GallerySettings::ThemeMode hostThemeMode(platform::HostTheme theme)
+{
+    if (theme == platform::HostTheme::Dark)
+        return GallerySettings::ThemeMode::Dark;
+    if (theme == platform::HostTheme::Light)
+        return GallerySettings::ThemeMode::Light;
+    return GallerySettings::ThemeMode::System;
+}
+
 } // namespace
 
 GallerySettings& GallerySettings::instance()
@@ -77,6 +86,15 @@ GallerySettings::GallerySettings(QObject* parent)
     : QObject(parent)
 {
     load();
+    if (platform::capabilities().hostControlsTheme) {
+        const ThemeMode initialHostMode = hostThemeMode(platform::hostTheme());
+        if (initialHostMode != ThemeMode::System)
+            m_themeMode = initialHostMode;
+        platform::setHostThemeChangedHandler(
+            this, [this](platform::HostTheme theme) {
+                applyHostThemeMode(hostThemeMode(theme));
+            });
+    }
     // Install the persisted brand style theme into the ThemeRegistry before any widget paints, so the
     // first frame already uses the right palette + radius. zh_CN: 在任何控件绘制前把持久化的品牌样式主题
     // 装入 ThemeRegistry,使首帧即用正确的调色板与圆角。
@@ -99,6 +117,10 @@ GallerySettings::GallerySettings(QObject* parent)
 
 void GallerySettings::setThemeMode(ThemeMode mode)
 {
+    if (platform::capabilities().hostControlsTheme) {
+        applyHostThemeMode(hostThemeMode(platform::hostTheme()));
+        return;
+    }
     if (m_themeMode == mode)
         return;
 
@@ -110,6 +132,22 @@ void GallerySettings::setThemeMode(ThemeMode mode)
     applyThemeMode();
     emit themeModeChanged(m_themeMode);
     LOG_INFO(QStringLiteral("GallerySettings themeModeChanged mode=%1")
+                 .arg(static_cast<int>(mode)));
+}
+
+void GallerySettings::applyHostThemeMode(ThemeMode mode)
+{
+    if (!platform::capabilities().hostControlsTheme
+        || mode == ThemeMode::System) {
+        return;
+    }
+    if (m_themeMode == mode)
+        return;
+
+    m_themeMode = mode;
+    applyThemeMode();
+    emit themeModeChanged(m_themeMode);
+    LOG_INFO(QStringLiteral("GallerySettings hostThemeChanged mode=%1")
                  .arg(static_cast<int>(mode)));
 }
 

--- a/app/viewmodel/GallerySettings.h
+++ b/app/viewmodel/GallerySettings.h
@@ -103,6 +103,7 @@ protected:
 
 private:
     explicit GallerySettings(QObject* parent = nullptr);
+    void applyHostThemeMode(ThemeMode mode);
     void applyThemeMode();
     void load();
 

--- a/bindings/pyside6/PUBLISHING.md
+++ b/bindings/pyside6/PUBLISHING.md
@@ -47,13 +47,16 @@ Create these GitHub deployment environments:
 |---|---|---|
 | `testpypi` | Selected branches matching `release/*` | Optional for the rehearsal |
 | `testpypi-gallery` | Selected branches matching `release/*` | Optional for the rehearsal |
-| `pypi` | Protected tags matching `v*` | Required reviewer: repository maintainer |
-| `pypi-gallery` | Protected tags matching `v*` | Required reviewer: repository maintainer |
+| `pypi` | Protected tags matching `v*` | Explicit production workflow dispatch |
+| `pypi-gallery` | Protected tags matching `v*` | Explicit production workflow dispatch |
 
-For a single-maintainer repository, leave **Prevent self-review** disabled on
-both production environments. Otherwise the only maintainer cannot approve the
-two production deployment jobs. Disable administrator bypass on all four
-environments so that the branch/tag and reviewer rules cannot be skipped.
+For a single-maintainer repository, do not configure required reviewers on the
+two production environments. The explicit `stage=pypi` workflow dispatch is
+the production approval, while the environments still enforce the `v*` tag
+boundary and package-scoped Trusted Publisher identities. Disable
+administrator bypass on all four environments so that branch and tag rules
+cannot be skipped. If release ownership later expands to multiple maintainers,
+required reviewers can be restored as an additional separation-of-duties gate.
 
 The `release/*` environment policy is intentionally reusable across release
 lines. The workflow applies the narrower check dynamically: a project version
@@ -165,11 +168,11 @@ gh workflow run python-release.yml \
 
 Production preflight rejects a lightweight or prerelease tag, version drift,
 a different TestPyPI/full-CI commit, an unpublished GitHub Release, an
-incomplete TestPyPI file set, or an existing production version. The upload
-jobs then pause at the `pypi` and `pypi-gallery` environments for maintainer
-approval. Both must be approved before the complete release can be verified.
+incomplete TestPyPI file set, or an existing production version. The manual
+workflow dispatch is the production authorization; after preflight, both
+package-scoped upload jobs proceed without a second deployment approval.
 
-After approval, the official PyPI publish action uploads the same 18 files
+The official PyPI publish action uploads the same 18 files
 through OIDC Trusted Publishing and creates attestations. Verification checks
 the public JSON hashes, validates all 18 attestations against
 `calvinhxx/Fluent-Qt`, and performs a normal clean-index installation of both

--- a/cmake/FluentQtInstallHeaders.cmake
+++ b/cmake/FluentQtInstallHeaders.cmake
@@ -22,6 +22,7 @@ set(FLUENT_QT_INSTALL_HEADERS
 
     src/compatibility/FontCompat.h
     src/compatibility/QtCompat.h
+    src/compatibility/TextPaintCompat.h
     src/compatibility/WindowChromeCompat.h
 
     src/components/basicinput/Button.h

--- a/docs/development/release-governance.md
+++ b/docs/development/release-governance.md
@@ -229,8 +229,10 @@ For releases that publish the optional PySide6 distributions, also follow the
 publication has an additional immutable-artifact sequence: full CI creates one
 18-wheel bundle, that exact bundle passes TestPyPI before the stable tag is
 created, and the tagged production workflow publishes the same files through
-Trusted Publishing after environment approval. A successful native wheel
-matrix alone is not a published Python release.
+Trusted Publishing after an explicit maintainer workflow dispatch. The
+production environments retain their `v*` tag restrictions without requiring
+a second deployment approval in the single-maintainer setup. A successful
+native wheel matrix alone is not a published Python release.
 
 Later automation may perform these steps, but the rules above remain the
 contract that CI, changelog, and packaging workflows should enforce.

--- a/docs/development/webassembly-roadmap.md
+++ b/docs/development/webassembly-roadmap.md
@@ -105,24 +105,27 @@ Feature integration is complete:
 4. The local and remote `codex/web-sup` branches, its rewrite worktree, and the
    requested temporary-branch Actions history were removed after integration.
 
-Promotion from `release/1.6.x` to `main` is maintainer-owned and must remain a
-manual repository-governance action. Automation and coding assistants must not
-perform that merge. The Pages workflow intentionally deploys only from `main`.
+Promotion from `release/1.6.x` to `main` is maintainer-owned and requires an
+explicit, per-PR maintainer instruction. Automation and coding assistants must
+not perform or bypass review for that merge without that authorization. The
+Pages workflow intentionally deploys only from `main`.
 
 ## Production acceptance after maintainer promotion
 
 This checklist validates the published artifact without blocking or reopening
 the completed development milestones:
 
-- [ ] A maintainer manually promotes the intended `release/1.6.x` revision to
-  `main`.
-- [ ] The Pages workflow deploys the staged payload successfully.
-- [ ] `https://calvinhxx.github.io/Fluent-Qt/gallery/` and its
+- [x] The maintainer explicitly authorized PR
+  [#29](https://github.com/calvinhxx/Fluent-Qt/pull/29) to rebase-promote
+  `release/1.6.x` revision `61b21b7` to `main` as `2d81131` after all fast and
+  full CI gates passed.
+- [x] The Pages workflow deploys the staged payload successfully.
+- [x] `https://calvinhxx.github.io/Fluent-Qt/gallery/` and its
   `hello-world/` consumer load over HTTPS without missing assets.
-- [ ] Production smoke covers startup, route navigation, browser text input,
+- [x] Production smoke covers startup, route navigation, browser text input,
   menus, resize/maximize, OpenWindow, Simplified Chinese fallback, and
   WebLocalStorage persistence.
-- [ ] Record the deployed revision, URL, date, and smoke result in the
+- [x] Record the deployed revision, URL, date, and smoke result in the
   verification log or release notes.
 
 ## Verification log
@@ -149,7 +152,8 @@ the completed development milestones:
 | 2026-08-10 | Release branch integration | Pass | PR [#27](https://github.com/calvinhxx/Fluent-Qt/pull/27) was consolidated into three commits and rebase-merged into `release/1.6.x` at `99701c3`; local and remote `codex/web-sup` refs were removed, while `main` remained unchanged. |
 | 2026-08-10 | Remote fast CI | Pass | PR #27 pre-integration fast CI passed the WebAssembly browser smoke, the three PySide6 compatibility/release paths, five native C++/integration paths, and `CI Gate`. Its temporary-branch Actions history is pruned after integration while this result summary remains in the roadmap. |
 | 2026-08-10 | Remote full CI | Pass | Pre-integration full CI passed all 44 jobs, including Qt 5.15/6.2 native compatibility, x64/ARM64 packages and tests, sanitizer contracts, Python 3.10-3.13 release wheels, `CI Gate`, and `Release ready`. The WebAssembly full smoke traversed all 88 routes in 9.705 s at DPR 2 / render DPR 1.25; browser elapsed time was 10.17 s, the slowest route took 168 ms, and heap capacity stayed at 128 MiB. The temporary-branch run record is intentionally removed after integration. |
-| 2026-08-10 | Pages deployment readiness | Pass | Fast and full CI staged and uploaded the `/gallery/` payload, including the minimal `hello-world/` consumer, licenses, and `build-info.json`. Public deployment awaits maintainer-owned promotion to `main` and is tracked by the production acceptance checklist. |
+| 2026-08-10 | Pages deployment readiness | Pass | Fast and full CI staged and uploaded the `/gallery/` payload, including the minimal `hello-world/` consumer, licenses, and `build-info.json`. At this pre-promotion checkpoint public deployment still awaited maintainer-owned promotion to `main`; the completed production acceptance is recorded below. |
+| 2026-08-10 | Production Pages acceptance | Pass | The maintainer explicitly authorized PR [#29](https://github.com/calvinhxx/Fluent-Qt/pull/29), whose fast CI passed 17/17 jobs and whose full CI passed 44/44 jobs after one transient macOS x64 offscreen segfault passed on failed-job retry. The PR was rebase-merged to `main` as `2d81131`. Pages run [31350526373](https://github.com/calvinhxx/Fluent-Qt/actions/runs/31350526373) rebuilt that revision, ran the full 88-route smoke in 9.99 s at DPR 2 / render DPR 1.25, and passed storage, window, dialog, menu, browser text input, text-menu, CJK fallback, bounded-memory, and windowed Hello World checks before deploying the same payload. Public `build-info.json` reports `2d81131`, Qt 6.9.3, Emscripten 3.1.70, and full validation; both the [Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/) and [Hello World](https://calvinhxx.github.io/Fluent-Qt/gallery/hello-world/) returned HTTPS 200, and a real browser rendered the windowed Gallery with opaque title chrome, navigation, content, and the welcome dialog. |
 
 ## Progress update rule
 

--- a/docs/releases/v1.6.2.md
+++ b/docs/releases/v1.6.2.md
@@ -1,0 +1,43 @@
+Fluent-Qt 1.6.2 brings the native C++ Qt Widgets experience to the browser
+through optional WebAssembly support, while keeping the existing desktop and
+PySide6 integration paths compatible by default.
+
+## WebAssembly support
+
+- Applications can opt in with `FLUENT_QT_BUILD_WEBASSEMBLY_SUPPORT` and use
+  the same installed `FluentQt::FluentQt` component library in Qt for
+  WebAssembly builds.
+- The C++ Gallery and Hello World example now have browser entry points,
+  platform capability routing, browser-safe logging, and documented Emscripten
+  workflows without coupling reusable controls to Gallery-specific code.
+- CI validates the WebAssembly build, browser startup, navigation, themes,
+  text input, menus, overlays, and staged GitHub Pages output.
+
+## Browser Gallery experience
+
+- The project website now presents the real C++ WebAssembly Gallery as a live,
+  interactive experience that loads lazily as it approaches the viewport.
+- Website light and dark modes propagate into the embedded Gallery, and the
+  standalone Gallery remains available for full-page testing.
+- Browser rendering uses adaptive resolution and bounded page residency to
+  reduce startup work, memory use, and high-DPI software-painting cost.
+
+## Interaction and visual fixes
+
+- Menus and text-editing context menus use browser-compatible non-blocking
+  popup lifecycles, with stable first-open geometry and rounded overlay masks.
+- Text fields, combo boxes, navigation entries, and collection samples share
+  tighter glyph metrics so text and cursors remain vertically aligned in the
+  browser.
+- Window surfaces, title bars, secondary windows, overscroll recovery, theme
+  changes, and the WebAssembly Gallery startup path now adapt to browser-hosted
+  constraints while preserving desktop defaults.
+
+## Compatibility
+
+- WebAssembly support remains opt-in; existing C++ desktop and PySide6 builds
+  do not acquire the WebAssembly runtime or bundled browser font resources.
+- The supported native baseline remains Qt 5.15+ or Qt 6.2+, while the
+  documented browser toolchain uses Qt 6.9.3 and Emscripten 3.1.70.
+
+[Compare v1.6.1...v1.6.2](https://github.com/calvinhxx/Fluent-Qt/compare/v1.6.1...v1.6.2)

--- a/site/index.html
+++ b/site/index.html
@@ -40,7 +40,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=20260811">
     <script src="site.js" defer></script>
   </head>
   <body>
@@ -253,40 +253,55 @@
             <article>
               <figure class="showcase-media">
                 <img
-                  src="assets/gallery/gallery-toggleswitch-real.png"
-                  data-theme-src-light="assets/gallery/gallery-toggleswitch-real.png"
-                  data-theme-src-dark="assets/gallery/gallery-toggleswitch-dark.png"
-                  alt="Fluent-Qt Gallery 中完整的 ToggleSwitch 控件页面"
-                  data-i18n-alt="images.toggle"
+                  src="assets/gallery/gallery-collections-real.png"
+                  data-theme-src-light="assets/gallery/gallery-collections-real.png"
+                  data-theme-src-dark="assets/gallery/gallery-collections-dark.png"
+                  alt="Fluent-Qt Gallery 中的集合视图页面"
+                  data-i18n-alt="images.collections"
                   width="1194"
                   height="774"
                   loading="lazy"
                   decoding="async"
                 >
               </figure>
-              <div class="pair-caption"><span>02 / STATEFUL</span><strong>ToggleSwitch</strong></div>
+              <div class="pair-caption"><span>02 / COLLECTIONS</span><strong>ListView · GridView · TreeView</strong></div>
             </article>
             <article>
               <figure class="showcase-media">
                 <img
-                  src="assets/gallery/gallery-slider-real.png"
-                  data-theme-src-light="assets/gallery/gallery-slider-real.png"
-                  data-theme-src-dark="assets/gallery/gallery-slider-dark.png"
-                  alt="Fluent-Qt Gallery 中完整的 Slider 控件页面"
-                  data-i18n-alt="images.slider"
+                  src="assets/gallery/gallery-home-real.png"
+                  data-theme-src-light="assets/gallery/gallery-home-real.png"
+                  data-theme-src-dark="assets/gallery/gallery-home-dark.png"
+                  alt="Fluent-Qt Gallery 的导航与窗口界面"
+                  data-i18n-alt="images.system"
                   width="1194"
                   height="774"
                   loading="lazy"
                   decoding="async"
                 >
               </figure>
-              <div class="pair-caption"><span>03 / LIVE VALUE</span><strong>Slider</strong></div>
+              <div class="pair-caption"><span>03 / SHELL</span><strong>Navigation · Windowing</strong></div>
             </article>
           </div>
 
           <div class="family-line" data-reveal>
-            <span data-i18n="components.familiesLabel">10 个控件家族</span>
-            <p data-i18n="components.families">基础输入 · 集合视图 · 日期与时间 · 对话框 · 菜单 · 导航 · 滚动 · 状态信息 · 文本输入 · 窗口系统</p>
+            <span data-i18n="components.familiesLabel">11 个控件家族</span>
+            <p data-i18n="components.families">基础输入 · 集合视图 · 日期与时间 · 对话框 · 布局 · 菜单 · 导航 · 滚动 · 状态信息 · 文本输入 · 窗口系统</p>
+          </div>
+
+          <div class="component-directory" aria-label="组件模块" data-i18n-aria-label="a11y.componentModules" data-reveal>
+            <article><strong>Foundation</strong><span>Theme · Typography · FontIcon</span></article>
+            <article><strong>Basic input</strong><span>Button · ComboBox · ToggleSwitch</span></article>
+            <article><strong>Collections</strong><span>ListView · GridView · TreeView</span></article>
+            <article><strong>Date &amp; time</strong><span>CalendarView · DatePicker · TimePicker</span></article>
+            <article><strong>Dialogs &amp; flyouts</strong><span>ContentDialog · Flyout · TeachingTip</span></article>
+            <article><strong>Layout</strong><span>Card · Accordion · Expander</span></article>
+            <article><strong>Menus &amp; toolbars</strong><span>Menu · MenuBar · CommandBar</span></article>
+            <article><strong>Navigation</strong><span>NavigationView · TabView · Breadcrumb</span></article>
+            <article><strong>Scrolling</strong><span>ScrollView · PipsPager · AnnotatedScrollBar</span></article>
+            <article><strong>Status &amp; info</strong><span>InfoBar · ProgressRing · Toast</span></article>
+            <article><strong>Text fields</strong><span>LineEdit · PasswordBox · AutoSuggestBox</span></article>
+            <article><strong>Windowing</strong><span>Window · TitleBar · WindowBackdrop</span></article>
           </div>
         </div>
       </section>
@@ -338,39 +353,87 @@ target_link_libraries(
       </section>
 
       <section class="gallery-section" id="gallery" aria-labelledby="gallery-title">
-        <div class="page-shell gallery-grid">
-          <figure class="gallery-product" data-reveal>
-            <div class="gallery-product-label"><span>GALLERY / SETTINGS</span><span data-theme-label data-theme-label-light="LIGHT" data-theme-label-dark="DARK">LIGHT</span></div>
-            <img
-              src="assets/gallery/gallery-collections-real.png"
-              data-theme-src-light="assets/gallery/gallery-collections-real.png"
-              data-theme-src-dark="assets/gallery/gallery-collections-dark.png"
-              alt="Fluent-Qt Gallery 设置页面，完整展示主题、风格和窗口选项"
-              data-i18n-alt="images.settings"
-              width="1194"
-              height="774"
-              loading="lazy"
-              decoding="async"
-            >
-          </figure>
-
-          <div class="gallery-copy" data-reveal data-reveal-delay="80">
-            <p class="section-index">05 / GALLERY</p>
-            <h2 id="gallery-title"><span data-i18n="gallery.title">Gallery 控件示例</span></h2>
-            <p data-i18n="gallery.copy">随仓库提供的桌面示例</p>
+        <div class="page-shell">
+          <div class="gallery-intro" data-reveal>
+            <div class="gallery-copy">
+              <p class="section-index">05 / GALLERY</p>
+              <h2 id="gallery-title"><span data-i18n="gallery.title">Gallery 控件示例</span></h2>
+              <p data-i18n="gallery.copy">随仓库提供的桌面示例</p>
+              <a
+                class="button button-primary gallery-web-link"
+                href="gallery/"
+                data-analytics-event="cpp_web_gallery"
+              >
+                <span data-i18n="gallery.webAction">运行 C++ Web Gallery</span>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7"/></svg>
+              </a>
+            </div>
             <ol class="workflow-list">
               <li><span>01</span><div><strong data-i18n="gallery.searchTitle">搜索</strong><p data-i18n="gallery.searchCopy">按控件名定位页面</p></div></li>
               <li><span>02</span><div><strong data-i18n="gallery.stateTitle">验证</strong><p data-i18n="gallery.stateCopy">切换 Light / Dark 与强调色</p></div></li>
               <li><span>03</span><div><strong data-i18n="gallery.codeTitle">查看示例</strong><p data-i18n="gallery.codeCopy">展开对应的 C++ 代码</p></div></li>
             </ol>
-            <a
-              class="button button-primary gallery-web-link"
-              href="gallery/"
-              data-analytics-event="cpp_web_gallery"
-            >
-              <span data-i18n="gallery.webAction">运行 C++ Web Gallery</span>
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7"/></svg>
-            </a>
+          </div>
+
+          <div
+            class="live-gallery-shell"
+            data-live-gallery
+            data-gallery-state="waiting"
+            data-gallery-src="gallery/?embed=site&amp;window-mode=maximized&amp;render-scale=1"
+            data-reveal
+          >
+            <div class="live-gallery-toolbar">
+              <div class="live-gallery-brand">
+                <span class="live-indicator" aria-hidden="true"></span>
+                <strong>C++ Web Gallery</strong>
+                <span class="live-gallery-status" data-gallery-status data-i18n="gallery.liveStateWaiting">等待进入视口</span>
+              </div>
+              <div class="live-gallery-actions">
+                <button type="button" class="live-toolbar-button" data-gallery-load>
+                  <span data-i18n="gallery.loadNow">立即加载</span>
+                </button>
+                <a class="live-toolbar-link" href="gallery/" target="_blank" rel="noopener">
+                  <span data-i18n="gallery.fullPage">完整页面</span> <span aria-hidden="true">↗</span>
+                </a>
+              </div>
+            </div>
+
+            <div class="live-gallery-viewport">
+              <img
+                class="live-gallery-poster"
+                src="assets/gallery/gallery-hero-real.png"
+                alt="C++ Web Gallery 加载前预览"
+                data-i18n-alt="images.webGallery"
+                width="1600"
+                height="900"
+                loading="lazy"
+                decoding="async"
+              >
+              <iframe
+                class="live-gallery-frame"
+                data-gallery-frame
+                title="Fluent-Qt C++ Web Gallery 实时体验"
+                data-i18n-title="gallery.frameTitle"
+                loading="lazy"
+                referrerpolicy="strict-origin-when-cross-origin"
+              ></iframe>
+              <div class="live-gallery-overlay" data-gallery-overlay role="status" aria-live="polite">
+                <span class="gallery-loader" aria-hidden="true"></span>
+                <strong data-gallery-message data-i18n="gallery.waitingTitle">滚动到这里后自动启动</strong>
+                <p data-gallery-detail data-i18n="gallery.waitingDetail">首屏不会请求 WebAssembly 文件；也可以现在手动加载。</p>
+                <div class="live-gallery-overlay-actions">
+                  <button type="button" class="button button-primary" data-gallery-load>
+                    <span data-i18n="gallery.loadAction">启动实时体验</span>
+                  </button>
+                  <a class="button button-quiet" href="gallery/" target="_blank" rel="noopener">
+                    <span data-i18n="gallery.openAction">在新页面打开</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+            <noscript>
+              <p class="noscript-note"><a href="gallery/">Open the C++ Web Gallery.</a></p>
+            </noscript>
           </div>
         </div>
       </section>

--- a/site/index.html
+++ b/site/index.html
@@ -339,7 +339,7 @@
 FetchContent_Declare(
   fluentqt
   GIT_REPOSITORY <span class="code-string">https://github.com/calvinhxx/Fluent-Qt.git</span>
-  GIT_TAG <span class="code-string">v1.6.1</span>
+  GIT_TAG <span class="code-string">v1.6.2</span>
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(fluentqt)

--- a/site/site.js
+++ b/site/site.js
@@ -12,6 +12,7 @@ const translations = {
     "a11y.useLightTheme": "切换到浅色主题",
     "a11y.specs": "项目规格",
     "a11y.downloads": "平台下载",
+    "a11y.componentModules": "组件模块",
     "a11y.heroTech": "C++17、Qt 5.15 或 Qt 6.2 及以上、MIT",
     "nav.why": "概览",
     "nav.components": "控件",
@@ -60,6 +61,27 @@ const translations = {
     "gallery.codeTitle": "查看示例",
     "gallery.codeCopy": "展开对应的 C++ 代码",
     "gallery.webAction": "运行 C++ Web Gallery",
+    "gallery.liveStateWaiting": "等待进入视口",
+    "gallery.liveStateLoading": "正在启动",
+    "gallery.liveStateReady": "可以操作",
+    "gallery.liveStateSlow": "仍在加载",
+    "gallery.liveStateError": "启动失败",
+    "gallery.loadNow": "立即加载",
+    "gallery.fullPage": "完整页面",
+    "gallery.waitingTitle": "滚动到这里后自动启动",
+    "gallery.waitingDetail": "首屏不会请求 WebAssembly 文件；也可以现在手动加载。",
+    "gallery.loadingTitle": "正在加载 Qt 与 C++ Gallery",
+    "gallery.loadingDetail": "首次下载取决于网络速度；完成后会直接显示可操作界面。",
+    "gallery.slowTitle": "下载仍在继续",
+    "gallery.slowDetail": "可以继续等待，或在新页面中打开完整 Gallery。",
+    "gallery.readyTitle": "Gallery 已就绪",
+    "gallery.readyDetail": "现在可以搜索组件、切换主题并操作示例。",
+    "gallery.errorTitle": "实时体验没有成功启动",
+    "gallery.errorDetail": "可以重试，或直接在完整页面中打开 Gallery。",
+    "gallery.loadAction": "启动实时体验",
+    "gallery.retryAction": "重新加载",
+    "gallery.openAction": "在新页面打开",
+    "gallery.frameTitle": "Fluent-Qt C++ Web Gallery 实时体验",
     "downloads.title": "下载 Gallery",
     "downloads.copy": "提供 Windows、macOS 与 Linux 安装包",
     "downloads.recommended": "为当前设备推荐",
@@ -76,6 +98,9 @@ const translations = {
     "images.button": "Fluent-Qt Gallery 中完整的 Button 控件页面",
     "images.toggle": "Fluent-Qt Gallery 中完整的 ToggleSwitch 控件页面",
     "images.slider": "Fluent-Qt Gallery 中完整的 Slider 控件页面",
+    "images.collections": "Fluent-Qt Gallery 中的集合视图页面",
+    "images.system": "Fluent-Qt Gallery 的导航与窗口界面",
+    "images.webGallery": "C++ Web Gallery 加载前预览",
     "images.settings": "Fluent-Qt Gallery 设置页面，完整展示主题、风格和窗口选项"
   },
   en: {
@@ -91,6 +116,7 @@ const translations = {
     "a11y.useLightTheme": "Switch to light theme",
     "a11y.specs": "Project specifications",
     "a11y.downloads": "Platform downloads",
+    "a11y.componentModules": "Component modules",
     "a11y.heroTech": "C++17, Qt 5.15 or Qt 6.2 and above, MIT",
     "nav.why": "Overview",
     "nav.components": "Controls",
@@ -139,6 +165,27 @@ const translations = {
     "gallery.codeTitle": "Open an example",
     "gallery.codeCopy": "Expand the corresponding C++ code",
     "gallery.webAction": "Run the C++ Web Gallery",
+    "gallery.liveStateWaiting": "Waiting for viewport",
+    "gallery.liveStateLoading": "Starting",
+    "gallery.liveStateReady": "Interactive",
+    "gallery.liveStateSlow": "Still loading",
+    "gallery.liveStateError": "Could not start",
+    "gallery.loadNow": "Load now",
+    "gallery.fullPage": "Full page",
+    "gallery.waitingTitle": "Starts automatically when you reach this section",
+    "gallery.waitingDetail": "The first viewport does not request the WebAssembly file. You can also start it now.",
+    "gallery.loadingTitle": "Loading Qt and the C++ Gallery",
+    "gallery.loadingDetail": "The first download depends on your connection. The interactive app appears as soon as it is ready.",
+    "gallery.slowTitle": "The download is still in progress",
+    "gallery.slowDetail": "Keep waiting or open the complete Gallery in a separate page.",
+    "gallery.readyTitle": "Gallery is ready",
+    "gallery.readyDetail": "Search controls, switch themes, and use the examples.",
+    "gallery.errorTitle": "The live Gallery did not start",
+    "gallery.errorDetail": "Retry here or open the full Gallery in a separate page.",
+    "gallery.loadAction": "Start live experience",
+    "gallery.retryAction": "Try again",
+    "gallery.openAction": "Open in a new page",
+    "gallery.frameTitle": "Live Fluent-Qt C++ Web Gallery",
     "downloads.title": "Download Gallery",
     "downloads.copy": "Packages are available for Windows, macOS, and Linux",
     "downloads.recommended": "Recommended for this device",
@@ -155,6 +202,9 @@ const translations = {
     "images.button": "Complete Button control page in Fluent-Qt Gallery",
     "images.toggle": "Complete ToggleSwitch control page in Fluent-Qt Gallery",
     "images.slider": "Complete Slider control page in Fluent-Qt Gallery",
+    "images.collections": "Collections page in Fluent-Qt Gallery",
+    "images.system": "Navigation and window UI in Fluent-Qt Gallery",
+    "images.webGallery": "C++ Web Gallery preview before loading",
     "images.settings": "Complete Gallery settings page showing theme, style, and window options"
   }
 };
@@ -178,6 +228,16 @@ const themeToggle = document.querySelector("[data-theme-toggle]");
 const copyAnnouncement = document.querySelector(".copy-announcement");
 const systemThemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 let followsSystemTheme = true;
+
+const galleryRoot = document.querySelector("[data-live-gallery]");
+const galleryFrame = document.querySelector("[data-gallery-frame]");
+const galleryStatus = document.querySelector("[data-gallery-status]");
+const galleryMessage = document.querySelector("[data-gallery-message]");
+const galleryDetail = document.querySelector("[data-gallery-detail]");
+const galleryLoadButtons = Array.from(document.querySelectorAll("[data-gallery-load]"));
+let galleryState = "waiting";
+let gallerySlowTimer = 0;
+let galleryRetry = 0;
 
 function dictionary() {
   return translations[releaseState.language] || translations.zh;
@@ -428,6 +488,15 @@ function updateThemeMedia(theme) {
   });
 }
 
+function syncGalleryTheme() {
+  if (!galleryFrame?.contentWindow || !galleryFrame.getAttribute("src")) return;
+  galleryFrame.contentWindow.postMessage({
+    source: "fluent-qt-site",
+    type: "theme",
+    theme: activeTheme()
+  }, window.location.origin);
+}
+
 function applyTheme(theme, shouldStore = false) {
   const normalized = theme === "dark" ? "dark" : "light";
   document.documentElement.dataset.theme = normalized;
@@ -435,6 +504,7 @@ function applyTheme(theme, shouldStore = false) {
   metaThemeColor?.setAttribute("content", normalized === "dark" ? "#070c12" : "#eef3f7");
   updateThemeMedia(normalized);
   updateThemeToggle();
+  syncGalleryTheme();
 
   if (shouldStore) {
     followsSystemTheme = false;
@@ -488,6 +558,37 @@ function updateMenuLabel() {
   menuButton.setAttribute("aria-label", dictionary()[menuIsOpen() ? "a11y.closeMenu" : "a11y.openMenu"]);
 }
 
+function renderGalleryState() {
+  if (!galleryRoot) return;
+  const values = dictionary();
+  const stateKeys = {
+    waiting: ["gallery.liveStateWaiting", "gallery.waitingTitle", "gallery.waitingDetail"],
+    loading: ["gallery.liveStateLoading", "gallery.loadingTitle", "gallery.loadingDetail"],
+    slow: ["gallery.liveStateSlow", "gallery.slowTitle", "gallery.slowDetail"],
+    ready: ["gallery.liveStateReady", "gallery.readyTitle", "gallery.readyDetail"],
+    error: ["gallery.liveStateError", "gallery.errorTitle", "gallery.errorDetail"]
+  };
+  const [statusKey, messageKey, detailKey] = stateKeys[galleryState] || stateKeys.waiting;
+  galleryRoot.dataset.galleryState = galleryState;
+  document.documentElement.dataset.galleryLoadState = galleryState;
+  if (galleryStatus) galleryStatus.textContent = values[statusKey];
+  if (galleryMessage) galleryMessage.textContent = values[messageKey];
+  if (galleryDetail) galleryDetail.textContent = values[detailKey];
+
+  const actionKey = galleryState === "error" ? "gallery.retryAction" : "gallery.loadAction";
+  galleryLoadButtons.forEach((button) => {
+    const label = button.querySelector("span") || button;
+    if (button.closest(".live-gallery-toolbar") && galleryState !== "error") {
+      label.textContent = values["gallery.loadNow"];
+    } else {
+      label.textContent = values[actionKey];
+    }
+    button.disabled = galleryState === "loading"
+      || galleryState === "slow"
+      || galleryState === "ready";
+  });
+}
+
 function setLanguage(language, shouldStore = true) {
   const normalized = language === "en" ? "en" : "zh";
   const values = translations[normalized];
@@ -508,6 +609,10 @@ function setLanguage(language, shouldStore = true) {
     const value = values[node.dataset.i18nAlt];
     if (value) node.setAttribute("alt", value);
   });
+  document.querySelectorAll("[data-i18n-title]").forEach((node) => {
+    const value = values[node.dataset.i18nTitle];
+    if (value) node.setAttribute("title", value);
+  });
   document.querySelectorAll("[data-readme-link]").forEach((link) => {
     link.href = normalized === "zh"
       ? "https://github.com/calvinhxx/Fluent-Qt/blob/main/README.zh-CN.md"
@@ -519,6 +624,7 @@ function setLanguage(language, shouldStore = true) {
 
   updateMenuLabel();
   updateThemeToggle();
+  renderGalleryState();
   updateDownloads();
   if (shouldStore) storeLanguage(normalized);
 }
@@ -580,6 +686,80 @@ async function copyCode(button) {
   }, 1500);
 }
 
+function galleryUrl(retry = false) {
+  const url = new URL(galleryRoot.dataset.gallerySrc, window.location.href);
+  url.searchParams.set("host-theme", activeTheme());
+  if (retry) url.searchParams.set("site-retry", String(galleryRetry));
+  return url.href;
+}
+
+function loadGallery(retry = false, trigger = "manual") {
+  if (!galleryRoot || !galleryFrame) return;
+  if (galleryState === "loading" || galleryState === "slow" || galleryState === "ready") return;
+
+  if (retry) galleryRetry += 1;
+  galleryState = "loading";
+  renderGalleryState();
+  window.clearTimeout(gallerySlowTimer);
+  gallerySlowTimer = window.setTimeout(() => {
+    if (galleryState === "loading") {
+      galleryState = "slow";
+      renderGalleryState();
+    }
+  }, 30000);
+  galleryFrame.src = galleryUrl(retry);
+  trackEvent("gallery_embed_start", { trigger, retry: String(galleryRetry) });
+}
+
+function setupLiveGallery() {
+  if (!galleryRoot || !galleryFrame) return;
+  renderGalleryState();
+  galleryLoadButtons.forEach((button) => {
+    button.addEventListener("click", () => loadGallery(galleryState === "error", "manual"));
+  });
+
+  window.addEventListener("message", (event) => {
+    if (event.origin !== window.location.origin || event.source !== galleryFrame.contentWindow) return;
+    if (event.data?.source !== "fluent-qt-gallery") return;
+    if (event.data.state === "ready") {
+      window.clearTimeout(gallerySlowTimer);
+      galleryState = "ready";
+      renderGalleryState();
+      syncGalleryTheme();
+      trackEvent("gallery_embed_ready", { load_ms: String(event.data.detail?.loadMs || "") });
+    } else if (event.data.state === "error" || event.data.state === "exit") {
+      window.clearTimeout(gallerySlowTimer);
+      galleryState = "error";
+      renderGalleryState();
+      trackEvent("gallery_embed_error", { state: event.data.state });
+    }
+  });
+
+  galleryFrame.addEventListener("load", () => {
+    syncGalleryTheme();
+    if (galleryState !== "loading" && galleryState !== "slow") return;
+    try {
+      if (!galleryFrame.contentDocument?.querySelector("#qt-container")) {
+        window.clearTimeout(gallerySlowTimer);
+        galleryState = "error";
+        renderGalleryState();
+      }
+    } catch {
+      // The Pages deployment is same-origin. A custom host can still use the
+      // Gallery's explicit postMessage contract as the authoritative signal.
+    }
+  });
+
+  if (!("IntersectionObserver" in window)) return;
+  const preloadMargin = navigator.connection?.saveData ? "0px" : "240px 0px";
+  const observer = new IntersectionObserver((entries) => {
+    if (!entries.some((entry) => entry.isIntersecting)) return;
+    observer.disconnect();
+    loadGallery(false, "viewport");
+  }, { rootMargin: preloadMargin, threshold: 0.01 });
+  observer.observe(galleryRoot);
+}
+
 function setupInteractions() {
   languageButtons.forEach((button) => {
     button.addEventListener("click", () => setLanguage(button.dataset.lang));
@@ -603,6 +783,7 @@ function setupInteractions() {
 loadAnalytics();
 setupNavigation();
 setupInteractions();
+setupLiveGallery();
 setupReveal();
 releaseState.platform = detectPlatform();
 setLanguage(savedLanguage() === "en" ? "en" : "zh", false);

--- a/site/styles.css
+++ b/site/styles.css
@@ -582,7 +582,7 @@ h3 {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 44%;
+  width: 41%;
   min-height: inherit;
   padding: 56px 0 58px 0;
   color: var(--hero-ink);
@@ -771,8 +771,8 @@ h3 {
   position: absolute;
   z-index: 1;
   top: 50%;
-  right: -2%;
-  width: 62%;
+  right: -1%;
+  width: 58%;
   margin: 0;
   perspective: 1600px;
   transform: translateY(-49%);
@@ -1137,8 +1137,11 @@ h3 {
 }
 
 .pair-caption strong {
+  max-width: 72%;
   font-size: 21px;
   font-weight: 600;
+  line-height: 1.35;
+  text-align: right;
 }
 
 .family-line {
@@ -1155,6 +1158,38 @@ h3 {
 .family-line > span {
   color: var(--dark-ink);
   font-weight: 650;
+}
+
+.component-directory {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 34px;
+  border-top: 1px solid var(--dark-line);
+  border-left: 1px solid var(--dark-line);
+}
+
+.component-directory article {
+  display: grid;
+  align-content: space-between;
+  min-height: 116px;
+  gap: 18px;
+  padding: 22px;
+  border-right: 1px solid var(--dark-line);
+  border-bottom: 1px solid var(--dark-line);
+  background: color-mix(in srgb, var(--charcoal-soft) 78%, transparent);
+}
+
+.component-directory strong {
+  color: var(--dark-ink);
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.component-directory span {
+  color: var(--dark-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.6;
 }
 
 .quick-start-section {
@@ -1327,6 +1362,262 @@ h3 {
   height: 60%;
   background: radial-gradient(ellipse, color-mix(in srgb, var(--accent) 10%, transparent), transparent 70%);
   pointer-events: none;
+}
+
+.gallery-intro {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(520px, 1.22fr);
+  align-items: end;
+  gap: 110px;
+  margin-bottom: 58px;
+}
+
+.gallery-intro .workflow-list {
+  margin-top: 0;
+}
+
+.live-gallery-shell {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  border: 1px solid var(--gallery-border);
+  border-radius: var(--radius-md);
+  background: var(--gallery-surface);
+  box-shadow: var(--gallery-shadow);
+}
+
+.live-gallery-toolbar {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 9px 12px 9px 17px;
+  border-bottom: 1px solid var(--gallery-divider);
+  color: var(--ink);
+  background: var(--gallery-header);
+}
+
+.live-gallery-brand,
+.live-gallery-actions {
+  display: flex;
+  align-items: center;
+}
+
+.live-gallery-brand {
+  min-width: 0;
+  gap: 10px;
+}
+
+.live-gallery-brand strong {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-gallery-status {
+  padding: 4px 8px;
+  border: 1px solid var(--gallery-divider);
+  border-radius: 999px;
+  color: var(--soft-muted);
+  background: var(--gallery-surface);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.live-indicator {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #8998a6;
+  box-shadow: 0 0 0 4px rgba(137, 152, 166, 0.14);
+}
+
+[data-gallery-state="loading"] .live-indicator,
+[data-gallery-state="slow"] .live-indicator {
+  background: #efad32;
+  box-shadow: 0 0 0 4px rgba(239, 173, 50, 0.16);
+  animation: gallery-pulse 1.3s ease-in-out infinite;
+}
+
+[data-gallery-state="ready"] .live-indicator {
+  background: var(--green);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--green) 18%, transparent);
+}
+
+[data-gallery-state="error"] .live-indicator {
+  background: #d04444;
+  box-shadow: 0 0 0 4px rgba(208, 68, 68, 0.16);
+}
+
+.live-gallery-actions {
+  flex: 0 0 auto;
+  gap: 7px;
+}
+
+.live-toolbar-button,
+.live-toolbar-link {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 11px;
+  border: 1px solid var(--gallery-divider);
+  border-radius: 9px;
+  color: var(--ink);
+  background: var(--gallery-surface);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.live-toolbar-button:disabled {
+  display: none;
+}
+
+.live-gallery-viewport {
+  position: relative;
+  min-height: 560px;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #e9eef3;
+}
+
+.live-gallery-poster,
+.live-gallery-frame,
+.live-gallery-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.live-gallery-poster {
+  z-index: 0;
+  object-fit: cover;
+  object-position: center;
+  filter: saturate(0.78) contrast(0.94);
+  transform: scale(1.01);
+  transition: opacity 360ms ease, filter 360ms ease;
+}
+
+.live-gallery-frame {
+  z-index: 1;
+  border: 0;
+  opacity: 0;
+  background: #e9eef3;
+  transition: opacity 300ms ease;
+}
+
+[data-gallery-state="ready"] .live-gallery-frame {
+  opacity: 1;
+}
+
+[data-gallery-state="ready"] .live-gallery-poster {
+  opacity: 0;
+}
+
+.live-gallery-overlay {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 32px;
+  color: #111820;
+  text-align: center;
+  background: radial-gradient(circle at 50% 44%, rgba(255, 255, 255, 0.97), rgba(239, 245, 249, 0.87) 48%, rgba(222, 231, 239, 0.72));
+  backdrop-filter: blur(16px) saturate(0.82);
+  transition: opacity 260ms ease, visibility 260ms ease;
+}
+
+:root[data-theme="dark"] .live-gallery-overlay {
+  color: #f2f7fb;
+  background: radial-gradient(circle at 50% 44%, rgba(25, 34, 43, 0.97), rgba(13, 20, 28, 0.9) 48%, rgba(5, 9, 14, 0.8));
+}
+
+[data-gallery-state="ready"] .live-gallery-overlay {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.live-gallery-overlay strong {
+  margin-top: 18px;
+  font-size: clamp(23px, 3vw, 36px);
+  letter-spacing: -0.035em;
+}
+
+.live-gallery-overlay p {
+  max-width: 580px;
+  margin: 10px auto 0;
+  color: #596978;
+  font-size: 13px;
+}
+
+:root[data-theme="dark"] .live-gallery-overlay p {
+  color: #a8b7c3;
+}
+
+.live-gallery-overlay-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+[data-gallery-state="loading"] .live-gallery-overlay-actions,
+[data-gallery-state="slow"] .live-gallery-overlay-actions {
+  display: none;
+}
+
+.gallery-loader {
+  display: none;
+  width: 34px;
+  height: 34px;
+  border: 3px solid rgba(13, 143, 168, 0.2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: gallery-spin 0.8s linear infinite;
+}
+
+[data-gallery-state="loading"] .gallery-loader,
+[data-gallery-state="slow"] .gallery-loader {
+  display: block;
+}
+
+[data-gallery-state="error"] .gallery-loader {
+  display: grid;
+  place-items: center;
+  border: 0;
+  color: #d04444;
+  animation: none;
+}
+
+[data-gallery-state="error"] .gallery-loader::before {
+  font-size: 30px;
+  font-weight: 800;
+  content: "!";
+}
+
+.noscript-note {
+  margin: 0;
+  padding: 12px 18px;
+  color: var(--gallery-copy);
+  text-align: center;
+}
+
+@keyframes gallery-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes gallery-pulse {
+  50% { opacity: 0.5; transform: scale(0.86); }
 }
 
 .gallery-grid {
@@ -1668,7 +1959,7 @@ h3 {
   }
 
   .hero-message {
-    width: 45%;
+    width: 43%;
   }
 
   .hero h1 { font-size: clamp(60px, 6.1vw, 78px); }
@@ -1690,8 +1981,8 @@ h3 {
   }
 
   .hero-product {
-    right: -6%;
-    width: 64%;
+    right: -1%;
+    width: 55%;
   }
 
   .hero-actions { gap: 10px; }
@@ -1722,6 +2013,8 @@ h3 {
     grid-template-columns: minmax(0, 1.3fr) minmax(330px, 0.7fr);
     gap: 56px;
   }
+
+  .gallery-intro { gap: 56px; }
 }
 
 @media (max-width: 900px) {
@@ -1802,6 +2095,24 @@ h3 {
   .gallery-grid,
   .download-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gallery-intro {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 34px;
+  }
+
+  .gallery-intro .workflow-list {
+    max-width: 720px;
+  }
+
+  .component-directory {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .live-gallery-viewport {
+    min-height: 520px;
+    aspect-ratio: 4 / 3;
   }
 
   .hero-stage {
@@ -2071,6 +2382,16 @@ h3 {
     margin-top: 54px;
   }
 
+  .component-directory {
+    grid-template-columns: minmax(0, 1fr);
+    margin-top: 28px;
+  }
+
+  .component-directory article {
+    min-height: 98px;
+    padding: 18px;
+  }
+
   .code-panel { border-radius: 12px; }
 
   .code-panel header {
@@ -2087,13 +2408,46 @@ h3 {
     line-height: 1.72;
   }
 
-  .gallery-product-label {
-    height: 40px;
-    font-size: 9px;
-  }
-
   .gallery-copy > p:not(.section-index) { margin-top: 24px; }
   .workflow-list { margin-top: 30px; }
+
+  .gallery-intro {
+    margin-bottom: 38px;
+  }
+
+  .live-gallery-shell {
+    border-radius: 12px;
+  }
+
+  .live-gallery-toolbar {
+    min-height: 52px;
+    padding: 8px 9px;
+  }
+
+  .live-gallery-status,
+  .live-toolbar-button {
+    display: none;
+  }
+
+  .live-toolbar-link {
+    min-height: 32px;
+    padding-inline: 9px;
+  }
+
+  .live-gallery-viewport {
+    height: min(620px, 78vh);
+    min-height: 500px;
+    aspect-ratio: auto;
+  }
+
+  .live-gallery-overlay {
+    padding: 22px;
+  }
+
+  .live-gallery-overlay-actions {
+    width: 100%;
+    flex-direction: column;
+  }
 
   .download-recommended { padding: 25px 22px; }
   .download-recommended strong { font-size: 20px; }

--- a/src/compatibility/TextPaintCompat.h
+++ b/src/compatibility/TextPaintCompat.h
@@ -1,5 +1,5 @@
-#ifndef FLUENTTEXTPAINTMETRICS_P_H
-#define FLUENTTEXTPAINTMETRICS_P_H
+#ifndef FLUENTTEXTPAINTCOMPAT_H
+#define FLUENTTEXTPAINTCOMPAT_H
 
 #include <QFontMetricsF>
 #include <QRectF>
@@ -7,12 +7,10 @@
 
 namespace fluent::painting {
 
-// QPainter's AlignVCenter centers the font line box, whose ascent and descent
-// are intentionally asymmetric. Center the glyph ink instead so a selected
-// row's text stays aligned with its center indicator across native and browser
-// font backends. This is a private paint helper, not widget geometry policy.
-// zh_CN: QPainter 的 AlignVCenter 居中的是上下不对称的字体行框。这里改为按字形
-// 实际墨迹居中，使选中行文字在原生与浏览器字体后端都能和中心指示条对齐。
+/**
+ * @brief Returns the vertical translation that centers visible glyph ink in a target rectangle.
+ * zh_CN: 返回将可见字形墨迹垂直居中到目标矩形所需的平移量。
+ */
 inline qreal verticallyCenteredTextInkOffset(const QRectF& targetRect,
                                               const QFontMetricsF& metrics,
                                               const QString& text)
@@ -31,6 +29,10 @@ inline qreal verticallyCenteredTextInkOffset(const QRectF& targetRect,
     return targetRect.center().y() - alignedInkCenter;
 }
 
+/**
+ * @brief Returns a text rectangle translated so its visible glyph ink is vertically centered.
+ * zh_CN: 返回经过垂直平移的文本矩形，使其可见字形墨迹居中。
+ */
 inline QRectF verticallyCenteredTextInkRect(const QRectF& targetRect,
                                             const QFontMetricsF& metrics,
                                             const QString& text)
@@ -39,6 +41,10 @@ inline QRectF verticallyCenteredTextInkRect(const QRectF& targetRect,
         0.0, verticallyCenteredTextInkOffset(targetRect, metrics, text));
 }
 
+/**
+ * @brief Returns the visible glyph-ink center for text drawn with vertical-center alignment.
+ * zh_CN: 返回使用垂直居中对齐绘制文本时的可见字形墨迹中心。
+ */
 inline qreal alignedTextInkCenterY(const QRectF& alignedRect,
                                    const QFontMetricsF& metrics,
                                    const QString& text)
@@ -52,4 +58,4 @@ inline qreal alignedTextInkCenterY(const QRectF& alignedRect,
 
 } // namespace fluent::painting
 
-#endif // FLUENTTEXTPAINTMETRICS_P_H
+#endif // FLUENTTEXTPAINTCOMPAT_H

--- a/src/components/basicinput/ComboBox.cpp
+++ b/src/components/basicinput/ComboBox.cpp
@@ -21,7 +21,7 @@
 #include "compatibility/QtCompat.h"
 #include "components/collections/ListView.h"
 #include "components/foundation/private/DpiPaintMetrics_p.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 #include "components/foundation/overlay/OverlayGeometry.h"
 #include "components/menus_toolbars/private/TextEditingMenu_p.h"
 #include "components/scrolling/ScrollBar.h"

--- a/src/components/basicinput/ComboBox.cpp
+++ b/src/components/basicinput/ComboBox.cpp
@@ -21,6 +21,7 @@
 #include "compatibility/QtCompat.h"
 #include "components/collections/ListView.h"
 #include "components/foundation/private/DpiPaintMetrics_p.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 #include "components/foundation/overlay/OverlayGeometry.h"
 #include "components/menus_toolbars/private/TextEditingMenu_p.h"
 #include "components/scrolling/ScrollBar.h"
@@ -33,7 +34,6 @@ static constexpr int kPopupWindowMargin = 4;
 static constexpr int kPopupItemOuterInset = 5;
 static constexpr int kPopupItemTextLeftInset = 16;
 static constexpr int kPopupItemTextRightInset = 8;
-static constexpr qreal kPopupTextOpticalOffsetY = -2.0;
 static constexpr int kClosedFieldTextFitClearance = ::Spacing::XSmall;
 
 // Suppress QStyle's PE_PanelLineEdit native panel — ComboBox paints its own bg
@@ -120,18 +120,20 @@ void ComboBoxItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& 
     const QRect logicalTextRect =
         logicalBgRect.adjusted(kPopupItemTextLeftInset, 0,
                                -kPopupItemTextRightInset, 0);
-    QRectF textRect =
+    const QRectF textSlot =
         QStyle::visualRect(option.direction, option.rect, logicalTextRect);
-    // Center the actual UI-font ink rather than its asymmetric ascent/descent line box.
-    // zh_CN: 按 UI 字体的字形墨迹居中，而不是按上下不对称的 ascent/descent 行框居中。
-    textRect.translate(0, kPopupTextOpticalOffsetY);
     painter->setPen(textColor);
     painter->setFont(option.font);
     const QString text = index.data(Qt::DisplayRole).toString();
+    const QFontMetricsF metrics(painter->font());
+    const QString elidedText = metrics.elidedText(
+        text, Qt::ElideRight, qRound(textSlot.width()));
+    const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+        textSlot, metrics, elidedText);
     painter->drawText(textRect,
                       QStyle::visualAlignment(option.direction,
                                               Qt::AlignLeft | Qt::AlignVCenter),
-                      painter->fontMetrics().elidedText(text, Qt::ElideRight, int(textRect.width())));
+                      elidedText);
 
     painter->restore();
 }
@@ -928,20 +930,23 @@ void ComboBox::paintEvent(QPaintEvent*) {
     const QRect logicalTextRect =
         rect().adjusted(m_contentPaddingH, m_contentPaddingV,
                         -chevronAreaW, -m_contentPaddingV);
-    QRectF textRect =
+    const QRectF textSlot =
         QStyle::visualRect(layoutDirection(), rect(), logicalTextRect);
-    // Figma: pb-[2px] on text wrapper
-    textRect.adjust(0, 0, 0, -2);
 
     // In editable mode, QLineEdit handles text display
     if (!m_observedLineEdit) {
         painter.setPen(textColor);
         painter.setFont(font());
         const QString text = currentText();
+        const QFontMetricsF metrics(painter.font());
+        const QString elidedText = metrics.elidedText(
+            text, Qt::ElideRight, qRound(textSlot.width()));
+        const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+            textSlot, metrics, elidedText);
         painter.drawText(textRect,
                          QStyle::visualAlignment(layoutDirection(),
                                                  Qt::AlignLeft | Qt::AlignVCenter),
-                         fontMetrics().elidedText(text, Qt::ElideRight, int(textRect.width())));
+                         elidedText);
     }
 
     // ── Chevron ──────────────────────────────────────────────────────────

--- a/src/components/foundation/overlay/OverlayGeometry.h
+++ b/src/components/foundation/overlay/OverlayGeometry.h
@@ -7,6 +7,7 @@
 #include <QPainterPath>
 #include <QPoint>
 #include <QRect>
+#include <QRegion>
 #include <QSize>
 #include <QVariant>
 #include <QWidget>
@@ -233,6 +234,29 @@ inline QPainterPath roundedRectPath(const QRectF& rect, qreal radius)
     }
     path.addRoundedRect(rect, radius, radius);
     return path;
+}
+
+inline QRegion roundedRectRegion(const QRect& rect, int radius)
+{
+    if (rect.isEmpty() || radius <= 0)
+        return QRegion(rect);
+
+    const int diameter = qMin(radius * 2, qMin(rect.width(), rect.height()));
+    const int effectiveRadius = diameter / 2;
+    QRegion region(rect.adjusted(effectiveRadius, 0, -effectiveRadius, 0));
+    region += QRegion(rect.adjusted(0, effectiveRadius, 0, -effectiveRadius));
+    region += QRegion(QRect(rect.topLeft(), QSize(diameter, diameter)), QRegion::Ellipse);
+    region += QRegion(QRect(QPoint(rect.right() - diameter + 1, rect.top()),
+                            QSize(diameter, diameter)),
+                      QRegion::Ellipse);
+    region += QRegion(QRect(QPoint(rect.left(), rect.bottom() - diameter + 1),
+                            QSize(diameter, diameter)),
+                      QRegion::Ellipse);
+    region += QRegion(QRect(QPoint(rect.right() - diameter + 1,
+                                   rect.bottom() - diameter + 1),
+                            QSize(diameter, diameter)),
+                      QRegion::Ellipse);
+    return region;
 }
 
 inline QPainterPath roundedCornerRectPath(const QRectF& rect, qreal radius,

--- a/src/components/foundation/private/TextPaintMetrics_p.h
+++ b/src/components/foundation/private/TextPaintMetrics_p.h
@@ -1,0 +1,55 @@
+#ifndef FLUENTTEXTPAINTMETRICS_P_H
+#define FLUENTTEXTPAINTMETRICS_P_H
+
+#include <QFontMetricsF>
+#include <QRectF>
+#include <QString>
+
+namespace fluent::painting {
+
+// QPainter's AlignVCenter centers the font line box, whose ascent and descent
+// are intentionally asymmetric. Center the glyph ink instead so a selected
+// row's text stays aligned with its center indicator across native and browser
+// font backends. This is a private paint helper, not widget geometry policy.
+// zh_CN: QPainter 的 AlignVCenter 居中的是上下不对称的字体行框。这里改为按字形
+// 实际墨迹居中，使选中行文字在原生与浏览器字体后端都能和中心指示条对齐。
+inline qreal verticallyCenteredTextInkOffset(const QRectF& targetRect,
+                                              const QFontMetricsF& metrics,
+                                              const QString& text)
+{
+    if (!targetRect.isValid() || targetRect.isEmpty() || text.isEmpty())
+        return 0.0;
+
+    const QRectF ink = metrics.tightBoundingRect(text);
+    if (!ink.isValid() || ink.isEmpty())
+        return 0.0;
+
+    const qreal alignedBaseline = targetRect.top()
+        + (targetRect.height() - metrics.height()) / 2.0
+        + metrics.ascent();
+    const qreal alignedInkCenter = alignedBaseline + ink.center().y();
+    return targetRect.center().y() - alignedInkCenter;
+}
+
+inline QRectF verticallyCenteredTextInkRect(const QRectF& targetRect,
+                                            const QFontMetricsF& metrics,
+                                            const QString& text)
+{
+    return targetRect.translated(
+        0.0, verticallyCenteredTextInkOffset(targetRect, metrics, text));
+}
+
+inline qreal alignedTextInkCenterY(const QRectF& alignedRect,
+                                   const QFontMetricsF& metrics,
+                                   const QString& text)
+{
+    const QRectF ink = metrics.tightBoundingRect(text);
+    const qreal baseline = alignedRect.top()
+        + (alignedRect.height() - metrics.height()) / 2.0
+        + metrics.ascent();
+    return baseline + ink.center().y();
+}
+
+} // namespace fluent::painting
+
+#endif // FLUENTTEXTPAINTMETRICS_P_H

--- a/src/components/menus_toolbars/Menu.cpp
+++ b/src/components/menus_toolbars/Menu.cpp
@@ -8,6 +8,8 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPointer>
+#include <QRegion>
+#include <QResizeEvent>
 #include <QShowEvent>
 #include <QTimer>
 #include <QVariantAnimation>
@@ -202,6 +204,7 @@ void FluentMenu::onThemeUpdated() {
     setContentsMargins(m_shadowSize, m_shadowSize + vPadding, m_shadowSize, m_shadowSize + vPadding);
     setItemLayoutMetrics(s.padding.listItemV, s.gap.normal + 1);
     setMinimumWidth(sizeHint().width());
+    updateSurfaceMask();
     updateGeometry();
     update();
 }
@@ -584,6 +587,39 @@ void FluentMenu::paintEvent(QPaintEvent* event) {
     p.restore();
 }
 
+void FluentMenu::resizeEvent(QResizeEvent* event) {
+    QMenu::resizeEvent(event);
+    updateSurfaceMask();
+}
+
+void FluentMenu::updateSurfaceMask() {
+    if (m_translucentSurface || rect().isEmpty()) {
+        // Do not clear a native/platform mask that QMenu may own. Only remove
+        // the opaque fallback mask installed by this class.
+        // zh_CN: 不清除 QMenu 可能持有的平台原生 mask；只移除本类为不透明
+        // 回退表面安装的遮罩。
+        if (m_surfaceMaskApplied) {
+            clearMask();
+            m_surfaceMaskApplied = false;
+        }
+        return;
+    }
+
+    // Browser popup windows use an opaque backing surface for stable text and
+    // animation. Clip that surface at the widget/window boundary so the full-
+    // rect opaque clear cannot leak through the painted rounded corners.
+    // QRegion is intentionally used only for the opaque fallback; translucent
+    // desktop popups keep their antialiased alpha edge and painted shadow.
+    // zh_CN: 浏览器 popup 使用不透明后备表面以保证文字与动画稳定。通过控件/
+    // 窗口边界遮罩裁掉矩形清屏的四角，避免覆盖后续绘制的圆角轮廓。QRegion 只
+    // 用于不透明回退；桌面透明 popup 继续使用抗锯齿 alpha 边缘与自绘阴影。
+    const QRegion surfaceMask = ::fluent::overlay::roundedRectRegion(
+        rect(), themeRadius().overlay);
+    if (mask() != surfaceMask)
+        setMask(surfaceMask);
+    m_surfaceMaskApplied = true;
+}
+
 QSize FluentMenu::sizeHint() const
 {
     QSize base = QMenu::sizeHint();
@@ -636,12 +672,25 @@ void FluentMenu::showEvent(QShowEvent* event) {
     if (::fluent::overlay::syncInheritedThemeOverride(this, parentWidget()))
         onThemeUpdated();
 
-    const QSize preferredSize = sizeHint();
-    const QSize targetSize = size().expandedTo(preferredSize);
+    // QMenu can enter showEvent() with a transient platform-window height that
+    // is larger than its already-settled sizeHint (notably on the first macOS
+    // popup). Treat the Fluent/native-combined hint as authoritative instead
+    // of preserving that one-shot excess with expandedTo(). Fixed widget size
+    // constraints are still honored by QWidget::resize().
+    // zh_CN: QMenu 首次进入 showEvent() 时，平台窗口高度可能暂时大于已经稳定的
+    // sizeHint（macOS 尤其明显）。以 Fluent/native 合并后的 hint 为准，避免
+    // expandedTo() 锁住这次性的多余高度；QWidget::resize() 仍会遵守固定尺寸约束。
+    const QSize targetSize = sizeHint();
     if (size() != targetSize) {
         resize(targetSize);
         updateGeometry();
     }
+    // QMenu's platform style may replace a mask while processing its base
+    // showEvent (macOS keeps only its own native corner convention). Reapply
+    // the Fluent surface mask after base-show geometry has settled.
+    // zh_CN: QMenu 平台样式可能在基类 showEvent 中替换 mask（macOS 会保留
+    // 自己的原生圆角约定）；基类显示几何稳定后重新应用 Fluent 表面遮罩。
+    updateSurfaceMask();
 
     // Compensate the shadow margin: top-level menus cancel it fully, cascaded
     // submenus keep a small gap so the parent's shadow never covers their content.
@@ -657,7 +706,7 @@ void FluentMenu::showEvent(QShowEvent* event) {
     move(targetPos);
     normalizePopupLayering();
     QTimer::singleShot(0, this, [this]() {
-        const QSize targetSize = size().expandedTo(sizeHint());
+        const QSize targetSize = sizeHint();
         bool geometryNeedsRefresh = false;
         for (QAction* action : actions()) {
             if (!action || action->isSeparator() || !action->isVisible())
@@ -678,6 +727,7 @@ void FluentMenu::showEvent(QShowEvent* event) {
             resize(targetSize + QSize(0, 1));
             resize(targetSize);
         }
+        updateSurfaceMask();
         normalizePopupLayering();
         update();
     });

--- a/src/components/menus_toolbars/Menu.h
+++ b/src/components/menus_toolbars/Menu.h
@@ -10,6 +10,7 @@
 class QActionEvent;
 class QKeyEvent;
 class QMouseEvent;
+class QResizeEvent;
 
 namespace fluent::menus_toolbars {
 
@@ -91,9 +92,11 @@ protected:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
     void showEvent(QShowEvent* event) override;
 
 private:
+    void updateSurfaceMask();
     void normalizePopupLayering();
     void drawShadow(QPainter& painter, const QRect& contentRect);
 
@@ -102,6 +105,7 @@ private:
     // 自绘阴影；不透明运行时回退使用完整 popup 矩形。
     int m_shadowSize = ::Spacing::Standard;
     bool m_translucentSurface = true;
+    bool m_surfaceMaskApplied = false;
     int m_itemVerticalPadding = ::Spacing::Padding::ListItemVertical;
     int m_separatorHeight = ::Spacing::Gap::Normal + 1;
 

--- a/src/components/textfields/AutoSuggestBox.cpp
+++ b/src/components/textfields/AutoSuggestBox.cpp
@@ -27,6 +27,7 @@
 #include "components/collections/ListView.h"
 #include "components/dialogs_flyouts/Flyout.h"
 #include "components/foundation/private/DpiPaintMetrics_p.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 
 namespace fluent::textfields {
 
@@ -91,10 +92,15 @@ public:
         painter->setFont(m_themeHost->themeFont(m_fontRole).toQFont());
         painter->setPen(textColor);
 
-        const QRectF textRect = QRectF(option.rect).adjusted(12, 0, -8, 0);
+        const QRectF textSlot = QRectF(option.rect).adjusted(12, 0, -8, 0);
         const QString display = index.data(Qt::DisplayRole).toString();
+        const QFontMetricsF metrics(painter->font());
+        const QString elidedText = metrics.elidedText(
+            display, Qt::ElideRight, qRound(textSlot.width()));
+        const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+            textSlot, metrics, elidedText);
         painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter,
-                          painter->fontMetrics().elidedText(display, Qt::ElideRight, int(textRect.width())));
+                          elidedText);
 
         painter->restore();
     }

--- a/src/components/textfields/AutoSuggestBox.cpp
+++ b/src/components/textfields/AutoSuggestBox.cpp
@@ -27,7 +27,7 @@
 #include "components/collections/ListView.h"
 #include "components/dialogs_flyouts/Flyout.h"
 #include "components/foundation/private/DpiPaintMetrics_p.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 
 namespace fluent::textfields {
 

--- a/src/components/windowing/Window.cpp
+++ b/src/components/windowing/Window.cpp
@@ -84,29 +84,6 @@ QPoint pointerLocalPosForWindow(QWidget* source, QWidget* window, QMouseEvent* e
     return source == window ? sourcePos : source->mapTo(window, sourcePos);
 }
 
-QRegion roundedRectRegion(const QRect& rect, int radius)
-{
-    if (rect.isEmpty() || radius <= 0)
-        return QRegion(rect);
-
-    const int diameter = qMin(radius * 2, qMin(rect.width(), rect.height()));
-    const int effectiveRadius = diameter / 2;
-    QRegion region(rect.adjusted(effectiveRadius, 0, -effectiveRadius, 0));
-    region += QRegion(rect.adjusted(0, effectiveRadius, 0, -effectiveRadius));
-    region += QRegion(QRect(rect.topLeft(), QSize(diameter, diameter)), QRegion::Ellipse);
-    region += QRegion(QRect(QPoint(rect.right() - diameter + 1, rect.top()),
-                            QSize(diameter, diameter)),
-                      QRegion::Ellipse);
-    region += QRegion(QRect(QPoint(rect.left(), rect.bottom() - diameter + 1),
-                            QSize(diameter, diameter)),
-                      QRegion::Ellipse);
-    region += QRegion(QRect(QPoint(rect.right() - diameter + 1,
-                                   rect.bottom() - diameter + 1),
-                            QSize(diameter, diameter)),
-                      QRegion::Ellipse);
-    return region;
-}
-
 } // namespace
 
 Window::Window(QWidget* parent)
@@ -1065,7 +1042,8 @@ void Window::syncClientSideFrameShape() {
     if (!qFuzzyCompare(m_frameHost->property(radiusProperty).toDouble() + 1.0, radius + 1.0))
         m_frameHost->setProperty(radiusProperty, radius);
     if (radius > 0.0) {
-        const QRegion frameMask = roundedRectRegion(m_frameHost->rect(), qCeil(radius));
+        const QRegion frameMask = ::fluent::overlay::roundedRectRegion(
+            m_frameHost->rect(), qCeil(radius));
         if (m_frameHost->mask() != frameMask)
             m_frameHost->setMask(frameMask);
     } else if (!m_frameHost->mask().isEmpty()) {

--- a/tests/components/basicinput/TestComboBox.cpp
+++ b/tests/components/basicinput/TestComboBox.cpp
@@ -32,6 +32,7 @@
 #include "components/foundation/FluentElement.h"
 #include "components/foundation/ThemeRegistry.h"
 #include "components/foundation/QMLPlus.h"
+#include "components/foundation/private/TextPaintMetrics_p.h"
 #include "design/Typography.h"
 
 using namespace fluent;
@@ -821,20 +822,38 @@ TEST_F(ComboBoxTest, PopupIndicatorAndTextShareOpticalCenterline) {
 
     const QModelIndex index = listView->model()->index(0, 0);
     const QRectF rowRect = static_cast<QListView*>(listView)->visualRect(index);
-    const QRectF textRect = rowRect.adjusted(5, 3, -5, -3).translated(0, -2);
+    const QRectF textSlot = rowRect.adjusted(5, 3, -5, -3);
     const QFontMetricsF metrics(listView->font());
-    const qreal baseline = textRect.top()
-        + (textRect.height() - metrics.height()) / 2.0
-        + metrics.ascent();
-    const qreal textInkCenter = baseline
-        + metrics.tightBoundingRect(index.data(Qt::DisplayRole).toString()).center().y();
+    const QString text = index.data(Qt::DisplayRole).toString();
+    const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+        textSlot, metrics, text);
+    const qreal textInkCenter = fluent::painting::alignedTextInkCenterY(
+        textRect, metrics, text);
 
-    // Offscreen font fallback on macOS/Linux can move tight ink bounds by a
-    // couple logical pixels while the visual centerline still reads aligned.
-    constexpr qreal kOpticalCenterTolerance = 2.5;
+    constexpr qreal kOpticalCenterTolerance = 0.01;
     EXPECT_NEAR(listView->selectedIndicatorRect().center().y(),
                 textInkCenter,
                 kOpticalCenterTolerance);
+}
+
+TEST_F(ComboBoxTest, TextInkCenteringAdaptsToRepresentativeGlyphProfiles) {
+    const QRectF textSlot(0.0, 0.0, 180.0, Spacing::ControlHeight::Large);
+    const QFontMetricsF metrics(window->font());
+    const QStringList samples{
+        QStringLiteral("Mica"),
+        QStringLiteral("gyp"),
+        QStringLiteral("2026"),
+        QString::fromUtf8("中文")
+    };
+
+    for (const QString& text : samples) {
+        SCOPED_TRACE(text.toStdString());
+        const QRectF textRect = fluent::painting::verticallyCenteredTextInkRect(
+            textSlot, metrics, text);
+        EXPECT_NEAR(textSlot.center().y(),
+                    fluent::painting::alignedTextInkCenterY(textRect, metrics, text),
+                    0.01);
+    }
 }
 
 // ─── Design-language × theme compatibility ──────────────────────────────────

--- a/tests/components/basicinput/TestComboBox.cpp
+++ b/tests/components/basicinput/TestComboBox.cpp
@@ -32,7 +32,7 @@
 #include "components/foundation/FluentElement.h"
 #include "components/foundation/ThemeRegistry.h"
 #include "components/foundation/QMLPlus.h"
-#include "components/foundation/private/TextPaintMetrics_p.h"
+#include "compatibility/TextPaintCompat.h"
 #include "design/Typography.h"
 
 using namespace fluent;

--- a/tests/components/menus_toolbars/TestMenu.cpp
+++ b/tests/components/menus_toolbars/TestMenu.cpp
@@ -1,15 +1,40 @@
 #include <gtest/gtest.h>
 
+#include <QRegion>
 #include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
 
 #include "components/foundation/ThemeRegistry.h"
 #include "components/menus_toolbars/Menu.h"
+#include "compatibility/private/RuntimePlatformCapabilities_p.h"
 #include "design/Spacing.h"
 #include "design/Typography.h"
 
 using fluent::ThemeRegistry;
 using fluent::menus_toolbars::FluentMenu;
 using fluent::menus_toolbars::FluentMenuItem;
+
+namespace {
+
+class RuntimeCapabilitiesScope final {
+public:
+    explicit RuntimeCapabilitiesScope(
+        const compatibility::detail::RuntimePlatformCapabilities& capabilities)
+        : m_previous(compatibility::detail::runtimePlatformCapabilities())
+    {
+        compatibility::detail::setRuntimePlatformCapabilities(capabilities);
+    }
+
+    ~RuntimeCapabilitiesScope()
+    {
+        compatibility::detail::setRuntimePlatformCapabilities(m_previous);
+    }
+
+private:
+    compatibility::detail::RuntimePlatformCapabilities m_previous;
+};
+
+} // namespace
 
 class MenuTest : public ::testing::Test {
 protected:
@@ -67,4 +92,66 @@ TEST_F(MenuTest, MultipleVisibleActionsContributeIndependentRowsToSizeHint) {
         + margins.top() + margins.bottom();
     EXPECT_GE(menu.sizeHint().height(), minimumRowsHeight)
         << "A multi-action popup must never collapse to a single WASM row";
+}
+
+TEST_F(MenuTest, OpaquePopupSurfaceUsesRoundedWindowMask) {
+    auto capabilities =
+        compatibility::detail::runtimePlatformCapabilities();
+    capabilities.translucentPopupSurfaces = false;
+    RuntimeCapabilitiesScope capabilityScope(capabilities);
+
+    FluentMenu menu(QStringLiteral("Actions"));
+    menu.addAction(QStringLiteral("Confirm selection"));
+    menu.addAction(QStringLiteral("Review changes"));
+    menu.popup(QPoint(100, 100));
+    QTRY_VERIFY(menu.isVisible());
+    QTest::qWait(20);
+
+    const QRegion surfaceMask = menu.mask();
+    ASSERT_FALSE(surfaceMask.isEmpty());
+    EXPECT_FALSE(surfaceMask.contains(menu.rect().topLeft()));
+    EXPECT_FALSE(surfaceMask.contains(menu.rect().topRight()));
+    EXPECT_FALSE(surfaceMask.contains(menu.rect().bottomRight()));
+    EXPECT_FALSE(surfaceMask.contains(menu.rect().bottomLeft()));
+    EXPECT_TRUE(surfaceMask.contains(menu.rect().center()));
+    menu.hide();
+}
+
+TEST_F(MenuTest, RepeatedPopupKeepsStableHeight) {
+    FluentMenu menu(QStringLiteral("Actions"));
+    menu.addAction(QStringLiteral("Confirm selection"));
+    menu.addAction(QStringLiteral("Review changes"));
+
+    menu.popup(QPoint(100, 100));
+    QTRY_VERIFY(menu.isVisible());
+    QTest::qWait(20);
+    const int firstHeight = menu.height();
+    const int firstHintHeight = menu.sizeHint().height();
+    const QList<QAction*> firstActions = menu.actions();
+    const int firstRowHeight = menu.actionGeometry(firstActions.constFirst()).height();
+
+    menu.hide();
+    QTRY_VERIFY(!menu.isVisible());
+
+    menu.popup(QPoint(100, 100));
+    QTRY_VERIFY(menu.isVisible());
+    QTest::qWait(20);
+    const int secondHeight = menu.height();
+    const int secondHintHeight = menu.sizeHint().height();
+    const QList<QAction*> secondActions = menu.actions();
+    const int secondRowHeight = menu.actionGeometry(secondActions.constFirst()).height();
+    menu.hide();
+
+    EXPECT_EQ(firstHeight, firstHintHeight)
+        << "The first popup must discard any transient platform-window excess";
+    EXPECT_EQ(secondHeight, secondHintHeight)
+        << "Later popups must continue to follow the settled size hint";
+    EXPECT_EQ(firstRowHeight, secondRowHeight)
+        << "Repeated popup must not change the action layout";
+    EXPECT_EQ(firstHeight, secondHeight)
+        << "The first popup must use the same settled geometry as later opens"
+        << "; first hint=" << firstHintHeight
+        << ", second hint=" << secondHintHeight
+        << ", first row=" << firstRowHeight
+        << ", second row=" << secondRowHeight;
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "fluent-qt",
-  "version-string": "1.6.1",
+  "version-string": "1.6.2",
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "dependencies": [],
   "features": {


### PR DESCRIPTION
## Summary

- add opt-in WebAssembly runtime support and the browser C++ Gallery
- integrate the live Gallery into the project website with lazy loading and theme synchronization
- stabilize browser menus, text metrics, window surfaces, and Gallery interaction behavior
- prepare the reviewed version metadata and public notes for v1.6.2

## Compatibility

- WebAssembly support remains opt-in
- existing desktop C++ and PySide6 integration paths stay enabled as before
- the native support baseline remains Qt 5.15+ or Qt 6.2+

## Validation

- project metadata validator
- nine-lane package-matrix validator
- Conventional Commit changelog check
- curated v1.6.2 release-note preview
- focused native component and Gallery tests
- full release CI: https://github.com/calvinhxx/Fluent-Qt/actions/runs/31411876235
