### PR TITLE
fix(site): preserve legacy Gallery URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ cmake --build build/fluentqt --target fluent_qt_source_package
 
 ### WebAssembly
 
-Use the [live WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/app/)
+Use the [live WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/)
 for evaluation. Local toolchain setup, builds, browser smoke tests, and Pages
 deployment are documented in the
 [WebAssembly workflow](docs/development/webassembly-workflow.md).
@@ -261,7 +261,7 @@ Start with the [documentation map](docs/README.md), or choose a path:
 
 | Goal | Entry point |
 |---|---|
-| Evaluate controls | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) · [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/app/) |
+| Evaluate controls | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) · [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/) |
 | Build an application | [AI-assisted development](docs/ai/README.md) · [Onboarding tools](tools/onboarding/README.md) · [PySide6](bindings/pyside6/README.md) |
 | Contribute to FluentQt | [Development tree](docs/development/README.md) · [Architecture](docs/architecture/README.md) · [Fluent design](docs/design-languages/README.md) |
 | Package or release | [Packaging](docs/development/packaging-workflow.md) · [Release governance](docs/development/release-governance.md) · [Release notes](docs/releases/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,7 +181,7 @@ cmake --build build/fluentqt --target fluent_qt_source_package
 
 ### WebAssembly
 
-评估项目时可直接使用[在线 WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/app/)。本地工具链、构建、浏览器冒烟测试和 Pages 部署统一见 [WebAssembly 工作流](docs/development/webassembly-workflow.md)。
+评估项目时可直接使用[在线 WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/)。本地工具链、构建、浏览器冒烟测试和 Pages 部署统一见 [WebAssembly 工作流](docs/development/webassembly-workflow.md)。
 
 ## 🖼 Gallery
 
@@ -246,7 +246,7 @@ python -m fluentqt_gallery
 
 | 目标 | 入口 |
 |---|---|
-| 体验和查找控件 | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) · [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/app/) |
+| 体验和查找控件 | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) · [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/) |
 | 构建应用 | [AI 辅助开发](docs/ai/README.md) · [环境检查与项目模板](tools/onboarding/README.md) · [PySide6](bindings/pyside6/README.md) |
 | 参与 FluentQt 开发 | [开发文档树](docs/development/README.md) · [架构约定](docs/architecture/README.md) · [Fluent 设计](docs/design-languages/README.md) |
 | 打包或发布 | [打包工作流](docs/development/packaging-workflow.md) · [发布治理](docs/development/release-governance.md) · [版本记录](docs/releases/README.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ need, and the development tree when you are changing the project itself.
 
 | Goal | Start here | Continue with |
 |---|---|---|
-| Try controls and copy an example | [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/app/) | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) |
+| Try controls and copy an example | [WebAssembly Gallery](https://calvinhxx.github.io/Fluent-Qt/gallery/) | [API Explorer](https://calvinhxx.github.io/Fluent-Qt/api/) |
 | Add FluentQt to a C++ or PySide6 application | [Project README](../README.md) | [Onboarding tools](../tools/onboarding/README.md) |
 | Add a GUI with a coding agent | [AI-assisted development](ai/README.md) | [Integration workflow](ai/add-gui-to-project.md) |
 | Add or change a component | [Development tree](development/README.md) | [Component API conventions](development/component-api-conventions.md) |

--- a/docs/development/site-workflow.md
+++ b/docs/development/site-workflow.md
@@ -24,6 +24,10 @@ render Chinese, while all other missing paths render English. It must not read
 browser-language state, and its assets and home links resolve from the
 `/Fluent-Qt/` project root even for deeply nested missing URLs.
 
+The legacy `/Fluent-Qt/app/` path is retained as a no-index redirect to the
+canonical `/Fluent-Qt/gallery/` page. Keep `site/app/index.html` when changing
+the Pages layout so links from older posts and bookmarks continue to work.
+
 ## Editing
 
 1. Edit the shared HTML structure in
@@ -49,8 +53,8 @@ python3 tools/site/generate_localized_site.py --check
 
 The check requires matching translation keys, static localized text and
 attributes, valid JSON-LD and sitemap XML, canonical URLs, reciprocal
-`hreflang` links, the URL-owned 404 language contract, and the current CMake
-project version in structured data.
+`hreflang` links, the URL-owned 404 language contract, the legacy Gallery
+redirect, and the current CMake project version in structured data.
 The Pages workflow also verifies that both localized pages and `sitemap.xml`
 are present before deployment.
 

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Opening the Fluent-Qt Gallery…</title>
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="https://calvinhxx.github.io/Fluent-Qt/gallery/">
+    <meta http-equiv="refresh" content="0; url=../gallery/">
+    <script>
+      (() => {
+        const target = new URL("../gallery/", window.location.href);
+        target.search = window.location.search;
+        target.hash = window.location.hash;
+        window.location.replace(target);
+      })();
+    </script>
+  </head>
+  <body>
+    <p>This Gallery has moved. <a href="../gallery/">Open the Fluent-Qt Gallery</a>.</p>
+  </body>
+</html>

--- a/tools/site/generate_localized_site.py
+++ b/tools/site/generate_localized_site.py
@@ -20,6 +20,7 @@ SITE_ROOT = ROOT / "site"
 TEMPLATE_PATH = Path(__file__).with_name("index.template.html")
 SITE_SCRIPT_PATH = SITE_ROOT / "site.js"
 ERROR_PAGE_PATH = SITE_ROOT / "404.html"
+LEGACY_GALLERY_REDIRECT_PATH = SITE_ROOT / "app" / "index.html"
 BASE_URL = "https://calvinhxx.github.io/Fluent-Qt/"
 REPOSITORY_URL = "https://github.com/calvinhxx/Fluent-Qt"
 OG_IMAGE_URL = f"{BASE_URL}assets/og.png"
@@ -367,6 +368,29 @@ def validate_error_page() -> None:
             fail(f"site/404.html must not infer language from browser state: {forbidden}")
 
 
+def validate_legacy_gallery_redirect() -> None:
+    try:
+        page = LEGACY_GALLERY_REDIRECT_PATH.read_text(encoding="utf-8")
+    except OSError as error:
+        fail(f"cannot read {LEGACY_GALLERY_REDIRECT_PATH}: {error}")
+
+    requirements = (
+        '<link rel="canonical" href="https://calvinhxx.github.io/Fluent-Qt/gallery/">',
+        '<meta http-equiv="refresh" content="0; url=../gallery/">',
+        'new URL("../gallery/", window.location.href)',
+        "target.search = window.location.search",
+        "target.hash = window.location.hash",
+        "window.location.replace(target)",
+        '<a href="../gallery/">Open the Fluent-Qt Gallery</a>',
+    )
+    for requirement in requirements:
+        if requirement not in page:
+            fail(
+                "site/app/index.html is missing legacy Gallery redirect contract: "
+                f"{requirement}"
+            )
+
+
 def output_digest(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
 
@@ -401,6 +425,7 @@ def main() -> int:
     localized_values = translations()
     version = project_version()
     validate_error_page()
+    validate_legacy_gallery_redirect()
     outputs: list[tuple[Path, str]] = []
 
     for locale in LOCALES:


### PR DESCRIPTION
## Summary

- update reader-facing Gallery links to the canonical `/gallery/` path
- retain `/app/` as a no-index compatibility redirect that preserves query strings and fragments
- validate and document the legacy redirect contract

## Validation

- `python3 tools/site/generate_localized_site.py --check`
- `python3 tools/docs/generate_navigation.py --project-root . --check`
- `python3 tools/docs/validate_documentation.py --project-root . --self-test`
- `git diff --check`