### PR TITLE
fix(pyside6): drain single-instance sockets before cleanup

### DIFF
--- a/bindings/pyside6/gallery/src/fluentqt_gallery/single_instance.py
+++ b/bindings/pyside6/gallery/src/fluentqt_gallery/single_instance.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 import hashlib
 import sys
 
+import shiboken6
 from PySide6.QtCore import (
     QByteArray,
     QDir,
@@ -15,6 +16,7 @@ from PySide6.QtCore import (
     QObject,
     QStandardPaths,
     QThread,
+    QTimer,
     Signal,
 )
 from PySide6.QtNetwork import QLocalServer, QLocalSocket
@@ -25,6 +27,7 @@ _ACTIVATED_REPLY = b"activated/1\n"
 _EXISTING_INSTANCE_TIMEOUT_MS = 2000
 _CONNECT_ATTEMPT_MS = 100
 _CONNECT_RETRY_DELAY_MS = 20
+_DISCONNECTED_SOCKET_DRAIN_MS = 20
 _MAXIMUM_COMMAND_BYTES = 256
 
 
@@ -114,6 +117,7 @@ class GallerySingleInstance(QObject):
         self._error_string = ""
         self._lock_file: QLockFile | None = None
         self._server: QLocalServer | None = None
+        self._accepted_sockets: dict[int, QLocalSocket] = {}
         self._start_result = StartResult.Error
         self._started = False
 
@@ -237,20 +241,47 @@ class GallerySingleInstance(QObject):
             if socket is None:
                 continue
             socket.setParent(self)
+            self._accepted_sockets[id(socket)] = socket
             socket.readyRead.connect(
                 lambda current=socket: self._process_socket(current)
             )
             socket.disconnected.connect(
                 lambda current=socket: self._socket_disconnected(current)
             )
-            if socket.bytesAvailable() > 0:
-                self._process_socket(socket)
+            # Drain once immediately: on Windows named pipes the peer can
+            # disconnect before PySide delivers the queued readyRead callback.
+            self._process_socket(socket)
 
     def _socket_disconnected(self, socket: QLocalSocket) -> None:
+        if not shiboken6.isValid(socket):
+            self._accepted_sockets.pop(id(socket), None)
+            return
         self._process_socket(socket)
-        socket.deleteLater()
+        if not shiboken6.isValid(socket):
+            self._accepted_sockets.pop(id(socket), None)
+            return
+        if socket.property("galleryInstanceCleanupScheduled"):
+            return
+        socket.setProperty("galleryInstanceCleanupScheduled", True)
+        # Keep the wrapper and native socket alive for one short drain window.
+        # Windows ARM64 can queue readyRead after disconnected; deleting here
+        # would make that callback observe an already-destroyed C++ object.
+        QTimer.singleShot(
+            _DISCONNECTED_SOCKET_DRAIN_MS,
+            lambda current=socket: self._finish_disconnected_socket(current),
+        )
+
+    def _finish_disconnected_socket(self, socket: QLocalSocket) -> None:
+        if shiboken6.isValid(socket):
+            self._process_socket(socket)
+        self._accepted_sockets.pop(id(socket), None)
+        if shiboken6.isValid(socket):
+            socket.deleteLater()
 
     def _process_socket(self, socket: QLocalSocket) -> None:
+        if not shiboken6.isValid(socket):
+            self._accepted_sockets.pop(id(socket), None)
+            return
         if socket.property("galleryInstanceHandled"):
             return
         previous = socket.property("galleryInstanceCommand")
@@ -283,6 +314,21 @@ class GallerySingleInstance(QObject):
             self._server.close()
             self._server.deleteLater()
             self._server = None
+        accepted_sockets = tuple(self._accepted_sockets.values())
+        self._accepted_sockets.clear()
+        for socket in accepted_sockets:
+            if not shiboken6.isValid(socket):
+                continue
+            try:
+                socket.readyRead.disconnect()
+            except (RuntimeError, TypeError):
+                pass
+            try:
+                socket.disconnected.disconnect()
+            except (RuntimeError, TypeError):
+                pass
+            socket.abort()
+            socket.deleteLater()
         if self._server_name and lock_file is not None and lock_file.isLocked():
             QLocalServer.removeServer(self._server_name)
         if lock_file is not None and lock_file.isLocked():

--- a/bindings/pyside6/gallery/tests/test_gallery.py
+++ b/bindings/pyside6/gallery/tests/test_gallery.py
@@ -742,38 +742,51 @@ print(int(result), flush=True)
 print(instance.error_string, flush=True)
 instance.close()
 """
-        worker = subprocess.Popen(
-            (
-                sys.executable,
-                "-c",
-                probe,
-                instance_id,
-                runtime.name,
-                QCoreApplication.applicationName(),
-                QCoreApplication.organizationName(),
-            ),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        callback_errors: list[tuple[object, ...]] = []
+        previous_excepthook = sys.excepthook
+        sys.excepthook = lambda *error: callback_errors.append(error)
         try:
-            for _attempt in range(250):
-                if worker.poll() is not None:
-                    break
-                _qwait(10)
-            stdout, stderr = worker.communicate(timeout=1.0)
-            _qwait(200)
-            output = stdout.splitlines()
-            self.assertEqual(worker.returncode, 0, stderr)
-            self.assertEqual(
-                int(output[0]), int(StartResult.ExistingInstanceNotified)
-            )
-            self.assertEqual(output[1:] or [""], [""])
-            self.assertEqual(activated, [True])
+            for expected_activation_count in range(1, 4):
+                worker = subprocess.Popen(
+                    (
+                        sys.executable,
+                        "-c",
+                        probe,
+                        instance_id,
+                        runtime.name,
+                        QCoreApplication.applicationName(),
+                        QCoreApplication.organizationName(),
+                    ),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                try:
+                    for _attempt in range(250):
+                        if worker.poll() is not None:
+                            break
+                        _qwait(10)
+                    stdout, stderr = worker.communicate(timeout=1.0)
+                    _qwait(200)
+                    output = stdout.splitlines()
+                    self.assertEqual(worker.returncode, 0, stderr)
+                    self.assertEqual(
+                        int(output[0]),
+                        int(StartResult.ExistingInstanceNotified),
+                    )
+                    self.assertEqual(output[1:] or [""], [""])
+                    self.assertEqual(
+                        activated,
+                        [True] * expected_activation_count,
+                    )
+                    self.assertEqual(primary._accepted_sockets, {})
+                finally:
+                    if worker.poll() is None:
+                        worker.kill()
+                        worker.wait(timeout=1.0)
+            self.assertEqual(callback_errors, [])
         finally:
-            if worker.poll() is None:
-                worker.kill()
-                worker.wait(timeout=1.0)
+            sys.excepthook = previous_excepthook
             primary.close()
 
     def test_python_and_native_galleries_have_independent_runtime_identity(self):

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -34,6 +34,9 @@ transition while keeping programmatic sizing synchronous.
 
 - The C++ and Python Galleries present matching theme and motion settings and
   use the public library APIs rather than Gallery-only styling.
+- The Python Gallery keeps accepted local activation sockets alive through the
+  disconnect drain window, preventing missed single-instance reactivation on
+  Windows ARM64.
 - The WebAssembly Gallery accepts Light, Dark, and High Contrast through its URL
   and message bridge, honors browser forced-colors, and restores the user's
   selected theme when forced-colors ends.


### PR DESCRIPTION
## Summary

- keep accepted QLocalSocket objects alive until queued data has been drained
- guard PySide6 callbacks against invalidated C++ wrappers and defer final cleanup briefly after disconnect
- strengthen the Gallery single-instance regression test with repeated secondary launches and uncaught-exception capture
- document the Windows ARM64 reactivation fix in the v1.8.0 release notes

## Local verification

- full Python Gallery CTest target: 70 tests passed
- Gallery-related CTest set: 5/5 passed
- focused stress test: 30 rounds, 90 cross-process activations passed
- Python compile check and documentation validation passed

Before merging, this PR will also run the Release Candidate workflow on its exact branch SHA to revalidate the original Windows ARM64 / CPython 3.11 failure lane.