### PR TITLE
fix(components): preserve inherited input signals

### DIFF
--- a/docs/development/component-api-audit.md
+++ b/docs/development/component-api-audit.md
@@ -10,6 +10,39 @@
 [← System capability delivery record](system-capability-roadmap.md) · [Contents](../SUMMARY.md) · [Development index](README.md)
 <!-- docs-nav:top:end -->
 
+## 2026-09-03 inherited input-signal addendum
+
+- The five public `QAbstractItemView`-derived collection controls were audited
+  against their inherited pointer-signal contract: `ListView`, `GridView`,
+  `FlowView`, `TreeView`, and `DataGrid`.
+- `ListView` and `FlowView` intercepted ordinary left-button input for custom
+  release-time selection but only emitted their row-based `itemClicked`
+  convenience signal. Their inherited `pressed(QModelIndex)` and
+  `clicked(QModelIndex)` signals were therefore silent.
+- `GridView`'s reorder path also intercepted presses on already-selected items.
+  It omitted inherited `pressed(QModelIndex)` and delegated release to
+  `QListView` even though the matching press had not reached the base class.
+  Consequently `clicked(QModelIndex)` depended on stale Qt press state and was
+  absent when the item had been selected programmatically before its first
+  pointer click. The intercepted path now completes both signals explicitly.
+- `TreeView` and `DataGrid` continue through their Qt base event chains and
+  already preserve both inherited signals. Focused tests now guard all five
+  components, including exact-once delivery and the GridView reorder branch.
+- A wider review of public Qt control subclasses found one additional exact-once
+  defect: `Slider` called `setSliderDown(false)`, which already emits inherited
+  `sliderReleased()`, and then emitted the same signal explicitly. The redundant
+  emission was removed and a real-pointer contract test now covers one press and
+  one release. Button, CheckBox, RadioButton, and ScrollBar already preserve
+  their Qt base input paths; split/menu button secondary hit zones remain
+  deliberate, separately tested activation surfaces.
+- The ListView Gallery cards did not expose the defect because they demonstrate
+  visible selection changes and do not connect the inherited signal to a
+  business action. Earlier ListView and GridView forwarding tests also invoked
+  `clicked(...)` synthetically instead of exercising the real pointer path.
+- The compatible repair restores the inherited signals without changing
+  release-time selection, drag suppression, row-based convenience signals, or
+  visible rendering. No new public API was added.
+
 ## 2026-08-29 static governance addendum
 
 The deferred component API static check is now implemented by
@@ -369,6 +402,8 @@ platform contracts.
 | API-010 | Low | Open setter alias | `src/components/basicinput/DropDownButton.h` | `DropDownButton` exposes `isOpen()` but only had `setOpen(bool)`, while other open-state components expose `setIsOpen(bool)`. | Applied compatible `setIsOpen(bool)` alias and focused test. Existing `setOpen(bool)` remains public. |
 | API-011 | Medium | Popup property notify gaps | `src/components/dialogs_flyouts/Popup.h`, `src/components/dialogs_flyouts/TeachingTip.h`, `src/components/dialogs_flyouts/ContentDialog.h` | Some overlay properties do not expose NOTIFY signals, but adding these signals should be paired with overlay-state semantics and binding tests rather than rushed into an API audit sweep. | Applied in 1.7-A with overlay-state semantics: NOTIFY + no-op on overlay bindable properties; focused `Contract_*` tests. |
 | API-012 | Medium | Typography precedence | `src/components/basicinput/Button.h`, `src/components/basicinput/ToggleSwitch.h`, `src/components/date_time/DatePicker.h`, `src/components/date_time/TimePicker.h` | Direct font initialization bypassed the semantic role property and left theme refresh versus caller `setFont(...)` precedence implicit; ToggleSwitch overwrote explicit fonts during refresh. | Added a source-compatible `Button::fontRole` contract and aligned ToggleSwitch precedence: theme-managed by default, explicit per-control font until the next `setFontRole(...)`; pickers and PySide6 inherit the Button contract. |
+| API-013 | High | Inherited item-view input signals | `src/components/collections/ListView.cpp`, `src/components/collections/GridView.cpp`, `src/components/collections/FlowView.cpp` | Custom pointer paths silently omitted inherited `pressed(QModelIndex)` and `clicked(QModelIndex)` despite public `QAbstractItemView` inheritance. GridView's intercepted release could appear to work only when Qt retained press state from an earlier base-class click. | Restored deterministic exact-once inherited signal delivery and added real-pointer contract coverage across all five public item-view collection controls, including programmatic preselection. |
+| API-014 | High | Inherited slider input signals | `src/components/basicinput/Slider.cpp` | The custom release path called `setSliderDown(false)`, which emits `sliderReleased()`, and then emitted `sliderReleased()` a second time. | Removed the redundant emission and added a real-pointer exact-once contract test. |
 
 ## Intentional Deviations
 
@@ -405,6 +440,16 @@ platform contracts.
   PySide6. `ToggleSwitch` now follows the same precedence with its existing
   `fontRole` API.
 - Added focused tests for the new aliases in DropDownButton, ListView, GridView, FlowView, TreeView, FlipView, TabView, and ProgressRing.
+- Restored inherited `pressed(QModelIndex)` and `clicked(QModelIndex)` delivery
+  across custom ListView and FlowView pointer paths and the intercepted GridView
+  reorder path. GridView now completes the click explicitly instead of relying
+  on unmatched `QListView::mouseReleaseEvent()` state. Real-pointer tests cover
+  ListView, GridView, FlowView, TreeView, and DataGrid, including a
+  programmatically preselected GridView item, and require exact-once delivery
+  alongside existing convenience signals.
+- Restored exact-once `QAbstractSlider::sliderReleased()` delivery in `Slider`;
+  the custom visual and tooltip release work now relies on the signal emitted by
+  `setSliderDown(false)` instead of emitting a duplicate.
 - Published the durable checklist as [Component API Conventions](component-api-conventions.md) so future work can use it without depending on an agent skill path.
 
 ## Deferred Follow-Ups
@@ -418,6 +463,16 @@ platform contracts.
 
 ## Validation Notes
 
+- The 2026-09-03 inherited input-signal repairs passed six focused component
+  targets on macOS Qt 6.9.3: 300 executed tests passed and 15 existing
+  manual/platform-dependent cases were skipped (nine GridView drag cases and
+  six VisualCheck cases). Eight direct pointer-signal contracts passed across
+  ListView, GridView, FlowView, TreeView, DataGrid, and Slider. The changes do
+  not alter rendered pixels, and no skipped VisualCheck is claimed as visual
+  approval.
+- The same working tree built `fluent_qt_gallery` and passed the component API,
+  accessibility inventory, visual evidence inventory, documentation
+  navigation, and documentation validation gates.
 - Date/time picker code changes were validated with focused builds and direct test binaries.
 - Alias sweep code changes were validated with focused builds and CTest label filters for `test_dropdown_button`, `test_list_view`, `test_grid_view`, `test_flow_view`, `test_tree_view`, `test_flip_view`, `test_tab_view`, and `test_progress_ring`: 289 tests passed, 0 failed, 8 VisualCheck tests skipped through `SKIP_VISUAL_TEST`.
 - Split/menu lifecycle changes were validated with the focused DropDownButton,

--- a/docs/development/component-api-conventions.md
+++ b/docs/development/component-api-conventions.md
@@ -109,6 +109,14 @@ APIs under `src/components/**`.
 - Light-dismiss behavior should be tested separately from programmatic close
   behavior.
 
+## Inherited Qt Interaction Contracts
+
+- Public components derived from an interactive Qt control must preserve the
+  base class's observable input signals with the same meaning and exact-once
+  delivery. An event override may call the Qt base implementation or reproduce
+  its signal contract explicitly; deliberate hit-zone exceptions must be
+  documented and covered by focused pointer tests.
+
 ## Selection and Current Item Naming
 
 - Selection APIs should distinguish selected item(s), current item, activation,
@@ -117,6 +125,12 @@ APIs under `src/components/**`.
   component-specific.
 - Signals named `activated`, `clicked`, `currentChanged`, or `selectionChanged`
   should match their Qt meaning where practical.
+- Public collection views derived from `QAbstractItemView` must preserve the
+  inherited `pressed(QModelIndex)` and `clicked(QModelIndex)` signals exactly
+  once on valid non-drag pointer paths, even when custom selection visuals,
+  release-time selection, or reorder handling intercepts the Qt event chain.
+  Component-specific `itemPressed` or `itemClicked` signals supplement those
+  inherited signals; they do not replace them.
 - Collection views should not own business item composition when model/delegate
   ownership is caller-provided.
 - Large item views must scale through `QAbstractItemModel`, views, and delegates.

--- a/src/components/basicinput/Slider.cpp
+++ b/src/components/basicinput/Slider.cpp
@@ -142,6 +142,8 @@ void Slider::mouseReleaseEvent(QMouseEvent* event)
     }
     event->accept();
     m_isPressed = false;
+    // QAbstractSlider emits sliderReleased() when sliderDown transitions to false.
+    // zh_CN: sliderDown 切换为 false 时，QAbstractSlider 会发送 sliderReleased()。
     setSliderDown(false);
 
     // Animate Release
@@ -160,7 +162,6 @@ void Slider::mouseReleaseEvent(QMouseEvent* event)
 
     triggerAction(SliderMove);
     update();
-    emit sliderReleased();
 }
 
 void Slider::showToolTip()

--- a/src/components/collections/FlowView.cpp
+++ b/src/components/collections/FlowView.cpp
@@ -72,6 +72,12 @@ FlowView::FlowView(QWidget* parent) : QAbstractItemView(parent)
     setDragEnabled(false);
     setDefaultDropAction(Qt::IgnoreAction);
 
+    // Keep the row-based convenience signal aligned with the inherited Qt
+    // item-view click contract.
+    // zh_CN: 让按行编号的便捷信号与继承的 Qt item-view 点击契约保持一致。
+    connect(this, &QAbstractItemView::clicked, this,
+            [this](const QModelIndex& index) { emit itemClicked(index.row()); });
+
     m_headerLabel = new QLabel(this);
     m_headerLabel->hide();
     m_headerLabel->setIndent(::Spacing::Padding::ListItemHorizontal);
@@ -524,9 +530,14 @@ void FlowView::mousePressEvent(QMouseEvent* event)
     }
 
     if (event->button() == Qt::LeftButton) {
+        setFocus(Qt::MouseFocusReason);
         const QModelIndex index = indexAt(fluentMousePos(event));
         if (index.isValid()) {
             m_pressedRow = index.row();
+            QPointer<FlowView> guard(this);
+            emit pressed(index);
+            if (!guard)
+                return;
             if (m_canReorderItems) {
                 m_dragStartPos = fluentMousePos(event);
                 m_dragSourceIndex = index.row();
@@ -539,7 +550,6 @@ void FlowView::mousePressEvent(QMouseEvent* event)
                 }
             }
         }
-        setFocus(Qt::MouseFocusReason);
         event->accept();
         return;
     }
@@ -673,7 +683,7 @@ void FlowView::mouseReleaseEvent(QMouseEvent* event)
 
     if (clickOnPressedItem) {
         QPointer<FlowView> guard(this);
-        emit itemClicked(releasedRow);
+        emit clicked(indexForRow(releasedRow));
         if (!guard)
             return;
     }

--- a/src/components/collections/FlowView.h
+++ b/src/components/collections/FlowView.h
@@ -20,7 +20,10 @@ class QTimer;
 class QWheelEvent;
 class QVariantAnimation;
 
-namespace fluent::scrolling { class ScrollBar; class OverscrollController; }
+namespace fluent::scrolling {
+class ScrollBar;
+class OverscrollController;
+} // namespace fluent::scrolling
 
 namespace fluent::collections {
 
@@ -43,7 +46,8 @@ public:
      * @brief Selection mode used by the collection view.
      * zh_CN: 集合视图使用的选择模式。
      */
-    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY
+                   selectionModeChanged)
     /**
      * @brief Fluent typography role used for text rendering.
      * zh_CN: 文本绘制使用的 Fluent 排版角色。
@@ -53,7 +57,8 @@ public:
      * @brief Whether the control frame border is painted.
      * zh_CN: 是否绘制控件外框边线。
      */
-    Q_PROPERTY(bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
+    Q_PROPERTY(
+        bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
     /**
      * @brief Convenience text displayed in the header area.
      * zh_CN: 显示在头部区域的便捷标题文本。
@@ -63,22 +68,26 @@ public:
      * @brief Text shown when the flow model has no items to present.
      * zh_CN: 流式 model 没有可展示 item 时显示的占位文本。
      */
-    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY placeholderTextChanged)
+    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY
+                   placeholderTextChanged)
     /**
      * @brief Default item size used when the model does not provide one.
      * zh_CN: model 未提供尺寸时使用的默认条目尺寸。
      */
-    Q_PROPERTY(QSize defaultItemSize READ defaultItemSize WRITE setDefaultItemSize NOTIFY defaultItemSizeChanged)
+    Q_PROPERTY(QSize defaultItemSize READ defaultItemSize WRITE setDefaultItemSize NOTIFY
+                   defaultItemSizeChanged)
     /**
      * @brief Minimum item size allowed by the flow layout.
      * zh_CN: 流式布局允许的最小条目尺寸。
      */
-    Q_PROPERTY(QSize minimumItemSize READ minimumItemSize WRITE setMinimumItemSize NOTIFY minimumItemSizeChanged)
+    Q_PROPERTY(QSize minimumItemSize READ minimumItemSize WRITE setMinimumItemSize NOTIFY
+                   minimumItemSizeChanged)
     /**
      * @brief Maximum item size allowed by the flow layout.
      * zh_CN: 流式布局允许的最大条目尺寸。
      */
-    Q_PROPERTY(QSize maximumItemSize READ maximumItemSize WRITE setMaximumItemSize NOTIFY maximumItemSizeChanged)
+    Q_PROPERTY(QSize maximumItemSize READ maximumItemSize WRITE setMaximumItemSize NOTIFY
+                   maximumItemSizeChanged)
     /**
      * @brief Model role used to resolve per-item size.
      * zh_CN: 用于解析单个条目尺寸的 model role。
@@ -88,17 +97,20 @@ public:
      * @brief Horizontal spacing between items.
      * zh_CN: 条目之间的水平间距。
      */
-    Q_PROPERTY(int horizontalSpacing READ horizontalSpacing WRITE setHorizontalSpacing NOTIFY horizontalSpacingChanged)
+    Q_PROPERTY(int horizontalSpacing READ horizontalSpacing WRITE setHorizontalSpacing NOTIFY
+                   horizontalSpacingChanged)
     /**
      * @brief Vertical spacing between items.
      * zh_CN: 条目之间的垂直间距。
      */
-    Q_PROPERTY(int verticalSpacing READ verticalSpacing WRITE setVerticalSpacing NOTIFY verticalSpacingChanged)
+    Q_PROPERTY(int verticalSpacing READ verticalSpacing WRITE setVerticalSpacing NOTIFY
+                   verticalSpacingChanged)
     /**
      * @brief Margins applied around the control content area.
      * zh_CN: 控件内容区域周围的边距。
      */
-    Q_PROPERTY(QMargins contentMargins READ contentMargins WRITE setContentMargins NOTIFY contentMarginsChanged)
+    Q_PROPERTY(QMargins contentMargins READ contentMargins WRITE setContentMargins NOTIFY
+                   contentMarginsChanged)
     /**
      * @brief Whether the item-view viewport is currently hovered.
      * zh_CN: item-view viewport 当前是否处于悬停状态。
@@ -108,18 +120,21 @@ public:
      * @brief Whether drag reordering is enabled.
      * zh_CN: 是否启用拖拽重排。
      */
-    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY canReorderItemsChanged)
+    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY
+                   canReorderItemsChanged)
     /**
      * @brief Whether boundary wheel input may continue to an enclosing scroller.
      * zh_CN: 边界滚轮输入是否允许继续传递给外层滚动容器。
      */
-    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
+    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE
+                   setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
     /**
      * @brief Whether the view shows an elastic overscroll/bounce at the scroll boundary.
      * Enabled by default; disable for chrome that should stop cleanly at the edge.
      * zh_CN: 滚动到边界时是否显示弹性回弹。默认开启；不希望回弹的 chrome 可关闭，使其在边界干脆停住。
      */
-    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY overscrollEnabledChanged)
+    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY
+                   overscrollEnabledChanged)
 
     explicit FlowView(QWidget* parent = nullptr);
     ~FlowView() override;
@@ -253,7 +268,8 @@ private:
     void invalidateFlowLayout();
     void syncFluentScrollBar();
     void ensureLayout() const;
-    void computeLayoutForRows(const QList<int>& rows, QHash<int, QRect>* rects, QSize* contentSize) const;
+    void computeLayoutForRows(const QList<int>& rows, QHash<int, QRect>* rects,
+                              QSize* contentSize) const;
     QSize itemSizeForIndex(const QModelIndex& index) const;
     QSize clampedItemSize(const QSize& size) const;
     QRect contentToViewport(const QRect& rect) const;

--- a/src/components/collections/FlowView.h
+++ b/src/components/collections/FlowView.h
@@ -204,6 +204,10 @@ signals:
     void canReorderItemsChanged();
     void scrollChainingEnabledChanged();
     void overscrollEnabledChanged();
+    /**
+     * @brief Emits the row once for the same pointer action as inherited clicked().
+     * zh_CN: 与继承的 clicked() 对应，在同一次指针点击中发送一次行号。
+     */
     void itemClicked(int row);
     void itemReordered(int fromIndex, int toIndex);
 

--- a/src/components/collections/GridView.cpp
+++ b/src/components/collections/GridView.cpp
@@ -648,6 +648,11 @@ void GridView::mousePressEvent(QMouseEvent* event)
                 selectionModel() && selectionModel()->isSelected(idx)) {
                 // Don't pass to QListView — preserve selection for drag
                 m_dragPressIntercepted = true;
+                setFocus(Qt::MouseFocusReason);
+                QPointer<GridView> guard(this);
+                emit pressed(idx);
+                if (!guard)
+                    return;
                 event->accept();
                 return;
             }
@@ -765,6 +770,8 @@ void GridView::mouseReleaseEvent(QMouseEvent* event)
 
     if (m_canReorderItems) {
         // No drag happened — apply deferred selection only if we intercepted the press
+        const bool interceptedPress = m_dragPressIntercepted;
+        QModelIndex interceptedClickIndex;
         if (m_dragPressIntercepted && m_dragSourceIndex >= 0 && model()) {
             QModelIndex idx = model()->index(m_dragSourceIndex, 0);
             if (m_selectionMode == SelectionMode::Multiple) {
@@ -775,10 +782,29 @@ void GridView::mouseReleaseEvent(QMouseEvent* event)
                 else
                     selectionModel()->select(idx, QItemSelectionModel::ClearAndSelect);
             }
+
+            const QModelIndex released = indexAt(event->pos());
+            if (event->button() == Qt::LeftButton && released.isValid() && released == idx)
+                interceptedClickIndex = idx;
         }
         m_dragSourceIndex = -1;
         m_dragSourceIndices.clear();
         m_dragPressIntercepted = false;
+
+        if (interceptedPress) {
+            m_pressedOnBlank = false;
+            if (interceptedClickIndex.isValid()) {
+                QPointer<GridView> guard(this);
+                // The matching press was intentionally not sent to QListView,
+                // so complete the inherited click contract here as well.
+                // zh_CN: 对应按下事件未交给 QListView，因此这里显式完成继承的点击契约。
+                emit clicked(interceptedClickIndex);
+                if (!guard)
+                    return;
+            }
+            event->accept();
+            return;
+        }
     }
     m_pressedOnBlank = false;
     QListView::mouseReleaseEvent(event);

--- a/src/components/collections/GridView.h
+++ b/src/components/collections/GridView.h
@@ -186,6 +186,10 @@ signals:
     void scrollChainingEnabledChanged();
     void overscrollEnabledChanged();
     void itemReordered(int fromIndex, int toIndex);
+    /**
+     * @brief Emits the row once for the same pointer action as inherited clicked().
+     * zh_CN: 与继承的 clicked() 对应，在同一次指针点击中发送一次行号。
+     */
     void itemClicked(int index);
 
 protected:

--- a/src/components/collections/GridView.h
+++ b/src/components/collections/GridView.h
@@ -16,7 +16,10 @@ class QTimer;
 class QVariantAnimation;
 class QWheelEvent;
 
-namespace fluent::scrolling { class ScrollBar; class OverscrollController; }
+namespace fluent::scrolling {
+class ScrollBar;
+class OverscrollController;
+} // namespace fluent::scrolling
 
 namespace fluent::collections {
 
@@ -39,7 +42,8 @@ public:
      * @brief Selection mode used by the collection view.
      * zh_CN: 集合视图使用的选择模式。
      */
-    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY
+                   selectionModeChanged)
     /**
      * @brief Fluent typography role used for text rendering.
      * zh_CN: 文本绘制使用的 Fluent 排版角色。
@@ -55,29 +59,34 @@ public:
      * @brief Whether drag reordering is enabled.
      * zh_CN: 是否启用拖拽重排。
      */
-    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY canReorderItemsChanged)
+    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY
+                   canReorderItemsChanged)
     /**
      * @brief Whether boundary wheel input may continue to an enclosing scroller.
      * zh_CN: 边界滚轮输入是否允许继续传递给外层滚动容器。
      */
-    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
+    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE
+                   setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
     /**
      * @brief Whether the view shows an elastic overscroll/bounce at the scroll boundary.
      * Enabled by default; disable for chrome that should stop cleanly at the edge.
      * zh_CN: 滚动到边界时是否显示弹性回弹。默认开启；不希望回弹的 chrome 可关闭，使其在边界干脆停住。
      */
-    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY overscrollEnabledChanged)
+    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY
+                   overscrollEnabledChanged)
 
     /**
      * @brief Whether the control frame border is painted.
      * zh_CN: 是否绘制控件外框边线。
      */
-    Q_PROPERTY(bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
+    Q_PROPERTY(
+        bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
     /**
      * @brief Whether the control background is painted.
      * zh_CN: 是否绘制控件背景。
      */
-    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY backgroundVisibleChanged)
+    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY
+                   backgroundVisibleChanged)
     /**
      * @brief Convenience text displayed in the header area.
      * zh_CN: 显示在头部区域的便捷标题文本。
@@ -87,7 +96,8 @@ public:
      * @brief Text shown when the grid model has no rows to present.
      * zh_CN: 网格 model 没有可展示行时显示的占位文本。
      */
-    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY placeholderTextChanged)
+    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY
+                   placeholderTextChanged)
 
     /**
      * @brief Grid cell size used for item layout.
@@ -98,12 +108,14 @@ public:
      * @brief Horizontal spacing between items.
      * zh_CN: 条目之间的水平间距。
      */
-    Q_PROPERTY(int horizontalSpacing READ horizontalSpacing WRITE setHorizontalSpacing NOTIFY horizontalSpacingChanged)
+    Q_PROPERTY(int horizontalSpacing READ horizontalSpacing WRITE setHorizontalSpacing NOTIFY
+                   horizontalSpacingChanged)
     /**
      * @brief Vertical spacing between items.
      * zh_CN: 条目之间的垂直间距。
      */
-    Q_PROPERTY(int verticalSpacing READ verticalSpacing WRITE setVerticalSpacing NOTIFY verticalSpacingChanged)
+    Q_PROPERTY(int verticalSpacing READ verticalSpacing WRITE setVerticalSpacing NOTIFY
+                   verticalSpacingChanged)
     /**
      * @brief Maximum number of columns; zero means unconstrained.
      * zh_CN: 最大列数，0 表示不限制。
@@ -253,11 +265,11 @@ private:
     QPoint m_dragStartPos;
     QPoint m_dragCurrentPos;
     QPixmap m_dragPixmap;
-    int  m_dragSourceIndex = -1;
+    int m_dragSourceIndex = -1;
     QList<int> m_dragSourceIndices;
-    int  m_dropTargetIndex = -1;
-    QHash<int, QPointF>            m_dragOffsets;
-    QHash<int, QPointF>            m_dragTargetOffsets;
+    int m_dropTargetIndex = -1;
+    QHash<int, QPointF> m_dragOffsets;
+    QHash<int, QPointF> m_dragTargetOffsets;
     QHash<int, QVariantAnimation*> m_dragAnims;
     mutable bool m_paintingWithOffsets = false;
 

--- a/src/components/collections/ListView.cpp
+++ b/src/components/collections/ListView.cpp
@@ -1210,6 +1210,10 @@ void ListView::mousePressEvent(QMouseEvent* event)
             if (m_canReorderItems)
                 m_dragSourceRow = idx.row();
             setFocus(Qt::MouseFocusReason);
+            QPointer<ListView> guard(this);
+            emit pressed(idx);
+            if (!guard)
+                return;
             event->accept();
             return;
         }
@@ -1312,7 +1316,11 @@ void ListView::mouseReleaseEvent(QMouseEvent* event)
         if (clickOnPressedItem) {
             applyPointerSelection(released, event);
             QPointer<ListView> guard(this);
-            emit itemClicked(released.row());
+            // Preserve QListView's inherited click contract. The constructor's
+            // clicked -> itemClicked bridge keeps the convenience signal in sync.
+            // zh_CN: 保留 QListView 继承的点击契约；构造函数中的转接会同步发送
+            // itemClicked 便捷信号。
+            emit clicked(released);
             if (!guard)
                 return;
         }

--- a/src/components/collections/ListView.h
+++ b/src/components/collections/ListView.h
@@ -24,7 +24,10 @@ class QVariantAnimation;
 class QWheelEvent;
 class QPropertyAnimation;
 
-namespace fluent::scrolling { class ScrollBar; class OverscrollController; }
+namespace fluent::scrolling {
+class ScrollBar;
+class OverscrollController;
+} // namespace fluent::scrolling
 
 namespace fluent::collections {
 
@@ -43,20 +46,15 @@ class ListView : public QListView, public FluentElement, public QMLPlus {
 public:
     using SelectionMode = ::fluent::collections::SelectionMode;
 
-    enum class IndicatorMotionDirection {
-        None,
-        Up,
-        Down,
-        Left,
-        Right
-    };
+    enum class IndicatorMotionDirection { None, Up, Down, Left, Right };
     Q_ENUM(IndicatorMotionDirection)
 
     /**
      * @brief Selection mode used by the collection view.
      * zh_CN: 集合视图使用的选择模式。
      */
-    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY
+                   selectionModeChanged)
     /**
      * @brief Fluent typography role used for text rendering.
      * zh_CN: 文本绘制使用的 Fluent 排版角色。
@@ -76,33 +74,40 @@ public:
      * @brief Animated progress for the selected-item indicator.
      * zh_CN: 选中项指示器的动画进度。
      */
-    Q_PROPERTY(qreal selectedIndicatorProgress READ selectedIndicatorProgress NOTIFY selectedIndicatorProgressChanged)
+    Q_PROPERTY(qreal selectedIndicatorProgress READ selectedIndicatorProgress NOTIFY
+                   selectedIndicatorProgressChanged)
     /**
      * @brief Direction used by selected-indicator motion.
      * zh_CN: 选中指示器动效使用的方向。
      */
-    Q_PROPERTY(IndicatorMotionDirection selectedIndicatorMotionDirection READ selectedIndicatorMotionDirection NOTIFY selectedIndicatorMotionDirectionChanged)
+    Q_PROPERTY(IndicatorMotionDirection selectedIndicatorMotionDirection READ
+                   selectedIndicatorMotionDirection NOTIFY selectedIndicatorMotionDirectionChanged)
     /**
      * @brief Whether selected-indicator animation is enabled.
      * zh_CN: 是否启用选中指示器动画。
      */
-    Q_PROPERTY(bool selectedIndicatorAnimationEnabled READ selectedIndicatorAnimationEnabled WRITE setSelectedIndicatorAnimationEnabled NOTIFY selectedIndicatorAnimationEnabledChanged)
+    Q_PROPERTY(
+        bool selectedIndicatorAnimationEnabled READ selectedIndicatorAnimationEnabled WRITE
+            setSelectedIndicatorAnimationEnabled NOTIFY selectedIndicatorAnimationEnabledChanged)
     /**
      * @brief Whether the selected-item indicator is painted.
      * zh_CN: 是否绘制选中项指示器。
      */
-    Q_PROPERTY(bool selectionIndicatorVisible READ selectionIndicatorVisible WRITE setSelectionIndicatorVisible NOTIFY selectionIndicatorVisibleChanged)
+    Q_PROPERTY(bool selectionIndicatorVisible READ selectionIndicatorVisible WRITE
+                   setSelectionIndicatorVisible NOTIFY selectionIndicatorVisibleChanged)
 
     /**
      * @brief Whether the control frame border is painted.
      * zh_CN: 是否绘制控件外框边线。
      */
-    Q_PROPERTY(bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
+    Q_PROPERTY(
+        bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
     /**
      * @brief Whether the control background is painted.
      * zh_CN: 是否绘制控件背景。
      */
-    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY backgroundVisibleChanged)
+    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY
+                   backgroundVisibleChanged)
     /**
      * @brief Custom widget hosted in the ListView header area.
      * zh_CN: 承载在 ListView 头部区域的自定义控件。
@@ -127,22 +132,26 @@ public:
      * @brief Text shown when the model has no rows to present.
      * zh_CN: model 没有可展示行时显示的占位文本。
      */
-    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY placeholderTextChanged)
+    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY
+                   placeholderTextChanged)
     /**
      * @brief Whether drag reordering is enabled.
      * zh_CN: 是否启用拖拽重排。
      */
-    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY canReorderItemsChanged)
+    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY
+                   canReorderItemsChanged)
     /**
      * @brief Whether boundary wheel input may continue to an enclosing scroller.
      * zh_CN: 边界滚轮输入是否允许继续传递给外层滚动容器。
      */
-    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
+    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE
+                   setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
     /**
      * @brief Whether section headers are enabled for grouped rows.
      * zh_CN: 是否为分组行启用 section header。
      */
-    Q_PROPERTY(bool sectionEnabled READ sectionEnabled WRITE setSectionEnabled NOTIFY sectionEnabledChanged)
+    Q_PROPERTY(bool sectionEnabled READ sectionEnabled WRITE setSectionEnabled NOTIFY
+                   sectionEnabledChanged)
 
     explicit ListView(QWidget* parent = nullptr);
     ~ListView() override;
@@ -151,7 +160,7 @@ public:
     void setSelectionModel(QItemSelectionModel* selectionModel) override;
 
     // --- Flow ---
-    using Flow = QListView::Flow;  // TopToBottom or LeftToRight
+    using Flow = QListView::Flow; // TopToBottom or LeftToRight
     Flow flow() const;
     void setFlow(Flow flow);
 
@@ -213,7 +222,10 @@ public:
 
     // --- Selected indicator motion API ---
     qreal selectedIndicatorProgress() const { return m_selectedIndicatorProgress; }
-    IndicatorMotionDirection selectedIndicatorMotionDirection() const { return m_selectedIndicatorMotionDirection; }
+    IndicatorMotionDirection selectedIndicatorMotionDirection() const
+    {
+        return m_selectedIndicatorMotionDirection;
+    }
     /** 控制 selected indicator 过渡动画；关闭后选择变更直接落到目标几何，便于确定性测试。 */
     bool selectedIndicatorAnimationEnabled() const { return m_selectedIndicatorAnimationEnabled; }
     bool isSelectedIndicatorAnimationEnabled() const { return selectedIndicatorAnimationEnabled(); }
@@ -288,7 +300,8 @@ protected:
     void leaveEvent(QEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
-    void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
+    void selectionChanged(const QItemSelection& selected,
+                          const QItemSelection& deselected) override;
     void scrollContentsBy(int dx, int dy) override;
     int verticalOffset() const override;
     int horizontalOffset() const override;
@@ -329,17 +342,21 @@ private:
     bool usesRevealSelectedIndicators() const;
     QRectF selectedIndicatorBaseRect(const QModelIndex& index) const;
     QRectF revealedSelectedIndicatorRect(const QRectF& baseRect, qreal progress) const;
-    QRectF interpolatedSelectedIndicatorRect(const QRectF& previous, const QRectF& target, qreal progress) const;
-    IndicatorMotionDirection classifySelectedIndicatorDirection(const QModelIndex& previous, const QModelIndex& current) const;
+    QRectF interpolatedSelectedIndicatorRect(const QRectF& previous, const QRectF& target,
+                                             qreal progress) const;
+    IndicatorMotionDirection classifySelectedIndicatorDirection(const QModelIndex& previous,
+                                                                const QModelIndex& current) const;
     void startSelectedIndicatorAnimation(bool animated);
-    void syncMultiSelectedIndicators(const QItemSelection& selected, const QItemSelection& deselected);
+    void syncMultiSelectedIndicators(const QItemSelection& selected,
+                                     const QItemSelection& deselected);
     void startMultiSelectedIndicatorReveal(const QModelIndex& index);
     qreal multiSelectedIndicatorProgress(const QModelIndex& index) const;
     void setSelectedIndicatorProgress(qreal progress);
     void setSelectedIndicatorMotionDirection(IndicatorMotionDirection direction);
     void refreshSelectedIndicatorGeometry(bool snapToTarget);
     void paintSelectedIndicator(QPainter& painter) const;
-    void paintIndicatorRect(QPainter& painter, const QRectF& indicatorRect, qreal opacity = 1.0) const;
+    void paintIndicatorRect(QPainter& painter, const QRectF& indicatorRect,
+                            qreal opacity = 1.0) const;
 
     SelectionMode m_selectionMode = SelectionMode::Single;
     Typography::FontRole m_fontRole = Typography::FontRole::Body;
@@ -352,8 +369,10 @@ private:
     QString m_placeholderText;
     QWidget* m_header = nullptr;
     QWidget* m_footer = nullptr;
-    bool m_ownsHeader = false;   // QLabel created internally via setHeaderText. zh_CN: 内部通过 setHeaderText 创建的 QLabel。
-    bool m_ownsFooter = false;   // QLabel created internally via setFooterText. zh_CN: 内部通过 setFooterText 创建的 QLabel。
+    bool m_ownsHeader =
+        false; // QLabel created internally via setHeaderText. zh_CN: 内部通过 setHeaderText 创建的 QLabel。
+    bool m_ownsFooter =
+        false; // QLabel created internally via setFooterText. zh_CN: 内部通过 setFooterText 创建的 QLabel。
 
     ::fluent::scrolling::ScrollBar* m_vScrollBar = nullptr;
     ::fluent::scrolling::ScrollBar* m_hScrollBar = nullptr;
@@ -363,15 +382,16 @@ private:
     // --- Drag reorder ---
     bool m_canReorderItems = false;
     bool m_isDragging = false;
-    int  m_pressedRow = -1;
-    int  m_pressedHoverRow = -1;
-    int  m_dragSourceRow = -1;
-    int  m_dropTargetRow = -1;      // Drop indicator position. zh_CN: 拖拽指示线位置。
+    int m_pressedRow = -1;
+    int m_pressedHoverRow = -1;
+    int m_dragSourceRow = -1;
+    int m_dropTargetRow = -1; // Drop indicator position. zh_CN: 拖拽指示线位置。
     QPoint m_dragStartPos;
     QPoint m_dragCurrentPos;
     QPixmap m_dragPixmap;
-    QHash<int, qreal>              m_dragOffsets;  // row → current Y offset in px. zh_CN: row → 当前 Y 位移。
-    QHash<int, QVariantAnimation*> m_dragAnims;    // row → displacement animation. zh_CN: row → 位移动画。
+    QHash<int, qreal> m_dragOffsets; // row → current Y offset in px. zh_CN: row → 当前 Y 位移。
+    QHash<int, QVariantAnimation*>
+        m_dragAnims; // row → displacement animation. zh_CN: row → 位移动画。
     mutable bool m_paintingWithOffsets = false;
 
     // --- Section ---

--- a/src/components/collections/ListView.h
+++ b/src/components/collections/ListView.h
@@ -269,6 +269,10 @@ signals:
     void selectedIndicatorMotionDirectionChanged();
     void selectedIndicatorAnimationEnabledChanged();
     void selectionIndicatorVisibleChanged();
+    /**
+     * @brief Emits the row once for the same pointer action as inherited clicked().
+     * zh_CN: 与继承的 clicked() 对应，在同一次指针点击中发送一次行号。
+     */
     void itemClicked(int index);
     void itemReordered(int fromRow, int toRow);
 

--- a/src/components/collections/TreeView.h
+++ b/src/components/collections/TreeView.h
@@ -19,7 +19,10 @@ class QVariantAnimation;
 class QWheelEvent;
 class QTimer;
 
-namespace fluent::scrolling { class ScrollBar; class OverscrollController; }
+namespace fluent::scrolling {
+class ScrollBar;
+class OverscrollController;
+} // namespace fluent::scrolling
 
 namespace fluent::collections {
 
@@ -38,19 +41,10 @@ class TreeView : public QTreeView, public FluentElement, public QMLPlus {
 public:
     using SelectionMode = ::fluent::collections::SelectionMode;
 
-    enum class IndicatorVerticalDirection {
-        None,
-        Up,
-        Down
-    };
+    enum class IndicatorVerticalDirection { None, Up, Down };
     Q_ENUM(IndicatorVerticalDirection)
 
-    enum class IndicatorHierarchyTransition {
-        None,
-        SameLevel,
-        Inward,
-        Outward
-    };
+    enum class IndicatorHierarchyTransition { None, SameLevel, Inward, Outward };
     Q_ENUM(IndicatorHierarchyTransition)
 
     /**
@@ -68,7 +62,8 @@ public:
      * @brief Selection mode used by the collection view.
      * zh_CN: 集合视图使用的选择模式。
      */
-    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY
+                   selectionModeChanged)
     /**
      * @brief Fluent typography role used for text rendering.
      * zh_CN: 文本绘制使用的 Fluent 排版角色。
@@ -83,38 +78,45 @@ public:
      * @brief Animated progress of the tree selection indicator.
      * zh_CN: 树选中指示器的动画进度。
      */
-    Q_PROPERTY(qreal indicatorMotionProgress READ indicatorMotionProgress NOTIFY indicatorMotionProgressChanged)
+    Q_PROPERTY(qreal indicatorMotionProgress READ indicatorMotionProgress NOTIFY
+                   indicatorMotionProgressChanged)
     /**
      * @brief Vertical direction used by tree indicator motion.
      * zh_CN: 树指示器动效使用的垂直方向。
      */
-    Q_PROPERTY(IndicatorVerticalDirection indicatorMotionDirection READ indicatorMotionDirection NOTIFY indicatorMotionDirectionChanged)
+    Q_PROPERTY(IndicatorVerticalDirection indicatorMotionDirection READ indicatorMotionDirection
+                   NOTIFY indicatorMotionDirectionChanged)
     /**
      * @brief Hierarchy transition mode used by tree indicator motion.
      * zh_CN: 树指示器动效使用的层级转场模式。
      */
-    Q_PROPERTY(IndicatorHierarchyTransition indicatorHierarchyTransition READ indicatorHierarchyTransition NOTIFY indicatorHierarchyTransitionChanged)
+    Q_PROPERTY(IndicatorHierarchyTransition indicatorHierarchyTransition READ
+                   indicatorHierarchyTransition NOTIFY indicatorHierarchyTransitionChanged)
     /**
      * @brief Whether tree indicator motion animation is enabled.
      * zh_CN: 是否启用树指示器动效动画。
      */
-    Q_PROPERTY(bool indicatorMotionAnimationEnabled READ isIndicatorMotionAnimationEnabled WRITE setIndicatorMotionAnimationEnabled NOTIFY indicatorMotionAnimationEnabledChanged)
+    Q_PROPERTY(bool indicatorMotionAnimationEnabled READ isIndicatorMotionAnimationEnabled WRITE
+                   setIndicatorMotionAnimationEnabled NOTIFY indicatorMotionAnimationEnabledChanged)
     /**
      * @brief Whether the Fluent horizontal scroll overlay is allowed to appear.
      * zh_CN: 控制 Fluent 水平滚动条覆盖层是否允许显示。
      */
-    Q_PROPERTY(bool horizontalFluentScrollBarEnabled READ isHorizontalFluentScrollBarEnabled WRITE setHorizontalFluentScrollBarEnabled)
+    Q_PROPERTY(bool horizontalFluentScrollBarEnabled READ isHorizontalFluentScrollBarEnabled WRITE
+                   setHorizontalFluentScrollBarEnabled)
 
     /**
      * @brief Whether the control frame border is painted.
      * zh_CN: 是否绘制控件外框边线。
      */
-    Q_PROPERTY(bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
+    Q_PROPERTY(
+        bool borderVisible READ borderVisible WRITE setBorderVisible NOTIFY borderVisibleChanged)
     /**
      * @brief Whether the control background is painted.
      * zh_CN: 是否绘制控件背景。
      */
-    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY backgroundVisibleChanged)
+    Q_PROPERTY(bool backgroundVisible READ backgroundVisible WRITE setBackgroundVisible NOTIFY
+                   backgroundVisibleChanged)
     /**
      * @brief Convenience text displayed in the header area.
      * zh_CN: 显示在头部区域的便捷标题文本。
@@ -124,18 +126,21 @@ public:
      * @brief Text shown when the tree model has no rows to present.
      * zh_CN: 树形 model 没有可展示行时显示的占位文本。
      */
-    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY placeholderTextChanged)
+    Q_PROPERTY(QString placeholderText READ placeholderText WRITE setPlaceholderText NOTIFY
+                   placeholderTextChanged)
 
     /**
      * @brief Whether drag reordering is enabled.
      * zh_CN: 是否启用拖拽重排。
      */
-    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY canReorderItemsChanged)
+    Q_PROPERTY(bool canReorderItems READ canReorderItems WRITE setCanReorderItems NOTIFY
+                   canReorderItemsChanged)
     /**
      * @brief Whether boundary wheel input may continue to an enclosing scroller.
      * zh_CN: 边界滚轮输入是否允许继续传递给外层滚动容器。
      */
-    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
+    Q_PROPERTY(bool scrollChainingEnabled READ isScrollChainingEnabled WRITE
+                   setScrollChainingEnabled NOTIFY scrollChainingEnabledChanged)
     /**
      * @brief Whether the view shows an elastic overscroll/bounce at the scroll boundary.
      * Enabled by default; disable for chrome (e.g. a navigation pane) that should stop
@@ -143,7 +148,8 @@ public:
      * zh_CN: 滚动到边界时是否显示弹性回弹。默认开启；用于不希望回弹的 chrome（如导航窗格）时关闭，
      * 使其在边界干脆停住、反向滚动立即响应。
      */
-    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY overscrollEnabledChanged)
+    Q_PROPERTY(bool overscrollEnabled READ isOverscrollEnabled WRITE setOverscrollEnabled NOTIFY
+                   overscrollEnabledChanged)
 
     explicit TreeView(QWidget* parent = nullptr);
     ~TreeView() override;
@@ -199,8 +205,14 @@ public:
 
     // --- Selected indicator motion API ---
     qreal indicatorMotionProgress() const { return m_indicatorMotionProgress; }
-    IndicatorVerticalDirection indicatorMotionDirection() const { return m_indicatorMotionDirection; }
-    IndicatorHierarchyTransition indicatorHierarchyTransition() const { return m_indicatorHierarchyTransition; }
+    IndicatorVerticalDirection indicatorMotionDirection() const
+    {
+        return m_indicatorMotionDirection;
+    }
+    IndicatorHierarchyTransition indicatorHierarchyTransition() const
+    {
+        return m_indicatorHierarchyTransition;
+    }
     bool isIndicatorMotionAnimationEnabled() const { return m_indicatorMotionAnimationEnabled; }
     void setIndicatorMotionAnimationEnabled(bool enabled);
     qreal selectedIndicatorProgress(const QModelIndex& index) const;
@@ -285,8 +297,8 @@ signals:
     void canReorderItemsChanged();
     void scrollChainingEnabledChanged();
     void overscrollEnabledChanged();
-    void itemReordered(const QModelIndex& srcParent, int srcRow,
-                       const QModelIndex& dstParent, int dstRow);
+    void itemReordered(const QModelIndex& srcParent, int srcRow, const QModelIndex& dstParent,
+                       int dstRow);
     void indicatorMotionProgressChanged();
     void indicatorMotionDirectionChanged();
     void indicatorHierarchyTransitionChanged();
@@ -305,10 +317,13 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
-    void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
+    void selectionChanged(const QItemSelection& selected,
+                          const QItemSelection& deselected) override;
     int verticalOffset() const override;
-    void drawRow(QPainter* painter, const QStyleOptionViewItem& options, const QModelIndex& index) const override;
-    void drawBranches(QPainter* painter, const QRect& rect, const QModelIndex& index) const override;
+    void drawRow(QPainter* painter, const QStyleOptionViewItem& options,
+                 const QModelIndex& index) const override;
+    void drawBranches(QPainter* painter, const QRect& rect,
+                      const QModelIndex& index) const override;
 
     void onThemeUpdated() override;
 
@@ -327,8 +342,11 @@ private:
     void startIndicatorMotionAnimation(bool animated);
     bool isIndicatorEndpointUsable(const QModelIndex& index) const;
     int indicatorHierarchyDepth(const QModelIndex& index) const;
-    IndicatorVerticalDirection classifyIndicatorVerticalDirection(const QModelIndex& previous, const QModelIndex& current) const;
-    IndicatorHierarchyTransition classifyIndicatorHierarchyTransition(const QModelIndex& previous, const QModelIndex& current) const;
+    IndicatorVerticalDirection classifyIndicatorVerticalDirection(const QModelIndex& previous,
+                                                                  const QModelIndex& current) const;
+    IndicatorHierarchyTransition
+    classifyIndicatorHierarchyTransition(const QModelIndex& previous,
+                                         const QModelIndex& current) const;
     void setIndicatorMotionProgress(qreal progress);
     void setIndicatorMotionDirection(IndicatorVerticalDirection direction);
     void setIndicatorHierarchyTransition(IndicatorHierarchyTransition transition);
@@ -341,7 +359,8 @@ private:
     // need full viewport recomposition; opaque views keep the smaller motion band.
     // zh_CN: 隐藏背景时需要整块重组父级表面；不透明视图仍只重绘动画经过的窄带。
     QRect indicatorMotionDirtyRect() const;
-    void syncCheckStatesWithSelection(const QItemSelection& selected, const QItemSelection& deselected);
+    void syncCheckStatesWithSelection(const QItemSelection& selected,
+                                      const QItemSelection& deselected);
     bool shouldSyncCheckStateWithSelection(const QModelIndex& index) const;
     void applyCheckStateToSubtree(const QModelIndex& index, Qt::CheckState state);
     void updateAncestorCheckStates(const QModelIndex& index);
@@ -385,7 +404,8 @@ private:
     QVariantAnimation* m_indicatorMotionAnim = nullptr;
     qreal m_indicatorMotionProgress = 1.0;
     IndicatorVerticalDirection m_indicatorMotionDirection = IndicatorVerticalDirection::None;
-    IndicatorHierarchyTransition m_indicatorHierarchyTransition = IndicatorHierarchyTransition::None;
+    IndicatorHierarchyTransition m_indicatorHierarchyTransition =
+        IndicatorHierarchyTransition::None;
     bool m_indicatorMotionAnimationEnabled = true;
     bool m_syncingCheckStateWithSelection = false;
 
@@ -402,16 +422,16 @@ private:
     QPoint m_dragCurrentPos;
     QPixmap m_dragPixmap;
     DropMode m_dropMode = DropMode::None;
-    QPersistentModelIndex m_dropTargetParent;  // parent for Between, unused for OnItem
-    int m_dropTargetRow = -1;                  // row index for Between, -1 for OnItem
-    QPersistentModelIndex m_dropOnIndex;       // target item for OnItem (re-parent)
+    QPersistentModelIndex m_dropTargetParent; // parent for Between, unused for OnItem
+    int m_dropTargetRow = -1;                 // row index for Between, -1 for OnItem
+    QPersistentModelIndex m_dropOnIndex;      // target item for OnItem (re-parent)
 
     // --- Expand animation ---
     QVariantAnimation* m_expandRevealAnim = nullptr;
     QPersistentModelIndex m_animParent;
     bool m_animEnabled = true;
-    bool m_animExpanding = true;   // true=expand, false=collapse
-    qreal m_animSubtreeHeight = 0.0;       // pixel height of the animating subtree
+    bool m_animExpanding = true;            // true=expand, false=collapse
+    qreal m_animSubtreeHeight = 0.0;        // pixel height of the animating subtree
     bool m_pendingCollapseFinalize = false; // deferred collapse: actually collapse on finish
 
 public:

--- a/src/components/collections/TreeView.h
+++ b/src/components/collections/TreeView.h
@@ -272,7 +272,15 @@ signals:
     void backgroundVisibleChanged();
     void headerTextChanged();
     void placeholderTextChanged();
+    /**
+     * @brief Mirrors the inherited pressed() signal for the same model index.
+     * zh_CN: 使用同一模型索引镜像继承的 pressed() 信号。
+     */
     void itemPressed(const QModelIndex& index);
+    /**
+     * @brief Mirrors the inherited clicked() signal for the same model index.
+     * zh_CN: 使用同一模型索引镜像继承的 clicked() 信号。
+     */
     void itemClicked(const QModelIndex& index);
     void canReorderItemsChanged();
     void scrollChainingEnabledChanged();

--- a/tests/components/basicinput/TestSlider.cpp
+++ b/tests/components/basicinput/TestSlider.cpp
@@ -3,9 +3,11 @@
 #include <QLabel>
 #include <QRadioButton>
 #include <QScrollArea>
+#include <QSignalSpy>
 
 #include <QSpinBox>
 #include <QStyle>
+#include <QTest>
 #include <QTimer>
 #include <gtest/gtest.h>
 #include "components/basicinput/Button.h"
@@ -81,6 +83,25 @@ TEST(SliderContractTest, Contract_DefaultMetricsAndQSliderSemantics)
     EXPECT_EQ(slider.trackHeight(), 6);
     EXPECT_DOUBLE_EQ(slider.hoverRatio(), 0.5);
     EXPECT_DOUBLE_EQ(slider.pressRatio(), 0.75);
+}
+
+TEST(SliderContractTest, Contract_PointerInteractionPreservesInheritedSignalsExactlyOnce)
+{
+    Slider slider(Qt::Horizontal);
+    slider.setRange(0, 100);
+    slider.resize(240, 40);
+
+    QSignalSpy pressedSpy(&slider, &QAbstractSlider::sliderPressed);
+    QSignalSpy releasedSpy(&slider, &QAbstractSlider::sliderReleased);
+
+    const QPoint center = slider.rect().center();
+    QTest::mousePress(&slider, Qt::LeftButton, Qt::NoModifier, center);
+    EXPECT_EQ(pressedSpy.count(), 1);
+    EXPECT_EQ(releasedSpy.count(), 0);
+
+    QTest::mouseRelease(&slider, Qt::LeftButton, Qt::NoModifier, center);
+    EXPECT_EQ(pressedSpy.count(), 1);
+    EXPECT_EQ(releasedSpy.count(), 1);
 }
 
 TEST(SliderContractTest, Contract_LightAndDarkRangeExtremesPaintDistinctly)

--- a/tests/components/basicinput/TestSlider.cpp
+++ b/tests/components/basicinput/TestSlider.cpp
@@ -28,7 +28,8 @@ class SliderFluentTestWindow : public QWidget, public fluent::FluentElement {
 public:
     using QWidget::QWidget;
 
-    void onThemeUpdated() override {
+    void onThemeUpdated() override
+    {
         const auto& c = themeColors();
         setStyleSheet(QString("background-color: %1;").arg(c.bgCanvas.name()));
     }
@@ -36,7 +37,8 @@ public:
 
 class SliderTest : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         scrollArea = new QScrollArea();
         scrollArea->setWindowTitle("Slider Visual Test (WinUI 3 Inspired)");
         scrollArea->resize(850, 600);
@@ -44,7 +46,7 @@ protected:
         window = new SliderFluentTestWindow();
         // Make window tall enough to show all content without being cut off
         window->setFixedSize(800, 950);
-        
+
         layout = new AnchorLayout(window);
         window->setLayout(layout);
         window->onThemeUpdated();
@@ -52,9 +54,7 @@ protected:
         scrollArea->setWidget(window);
     }
 
-    void TearDown() override {
-        delete scrollArea;
-    }
+    void TearDown() override { delete scrollArea; }
 
     QScrollArea* scrollArea = nullptr;
     SliderFluentTestWindow* window = nullptr;
@@ -106,8 +106,7 @@ TEST(SliderContractTest, Contract_PointerInteractionPreservesInheritedSignalsExa
 
 TEST(SliderContractTest, Contract_LightAndDarkRangeExtremesPaintDistinctly)
 {
-    const FluentElement::Theme themes[]{FluentElement::Light,
-                                        FluentElement::Dark};
+    const FluentElement::Theme themes[]{FluentElement::Light, FluentElement::Dark};
     for (const auto theme : themes) {
         FluentElement::setTheme(theme);
         Slider slider(Qt::Horizontal);
@@ -128,7 +127,8 @@ TEST(SliderContractTest, Contract_LightAndDarkRangeExtremesPaintDistinctly)
     FluentElement::setTheme(FluentElement::Light);
 }
 
-TEST_F(SliderTest, VisualSliderGalleryLike) {
+TEST_F(SliderTest, VisualSliderGalleryLike)
+{
     if (qEnvironmentVariableIsSet("SKIP_VISUAL_TEST")) {
         GTEST_SKIP() << "Set SKIP_VISUAL_TEST=1 to skip visual tests";
     }
@@ -154,10 +154,10 @@ TEST_F(SliderTest, VisualSliderGalleryLike) {
     layout->addWidget(pageTitle);
 
     Label* pageDesc = new Label("Use a Slider when you want your users to be able to set "
-                "defined, contiguous values "
-                "(such as volume or brightness) or a range of discrete values "
-                "(such as screen resolution settings).",
-        window);
+                                "defined, contiguous values "
+                                "(such as volume or brightness) or a range of discrete values "
+                                "(such as screen resolution settings).",
+                                window);
     pageDesc->setWordWrap(true);
     pageDesc->anchors()->top = {pageTitle, Edge::Bottom, 8};
     pageDesc->anchors()->left = {window, Edge::Left, 40};
@@ -192,7 +192,7 @@ TEST_F(SliderTest, VisualSliderGalleryLike) {
 
     Slider* rangeSlider = new Slider(Qt::Horizontal, window);
     rangeSlider->setRange(500, 1000);
-    rangeSlider->setSingleStep(10);  // SmallChange
+    rangeSlider->setSingleStep(10); // SmallChange
     rangeSlider->setPageStep(50);
     rangeSlider->setValue(800);
     rangeSlider->setFixedWidth(260);
@@ -233,14 +233,14 @@ TEST_F(SliderTest, VisualSliderGalleryLike) {
     QSpinBox* stepSpin = createSpinRow("StepFrequency:", rangeSlider->singleStep(), 2);
     QSpinBox* smallSpin = createSpinRow("SmallChange:", rangeSlider->singleStep(), 3);
 
-    QObject::connect(minSpin, qOverload<int>(&QSpinBox::valueChanged),
-                     rangeSlider, &QSlider::setMinimum);
-    QObject::connect(maxSpin, qOverload<int>(&QSpinBox::valueChanged),
-                     rangeSlider, &QSlider::setMaximum);
-    QObject::connect(stepSpin, qOverload<int>(&QSpinBox::valueChanged),
-                     rangeSlider, &QSlider::setTickInterval);
-    QObject::connect(smallSpin, qOverload<int>(&QSpinBox::valueChanged),
-                     rangeSlider, &QSlider::setSingleStep);
+    QObject::connect(minSpin, qOverload<int>(&QSpinBox::valueChanged), rangeSlider,
+                     &QSlider::setMinimum);
+    QObject::connect(maxSpin, qOverload<int>(&QSpinBox::valueChanged), rangeSlider,
+                     &QSlider::setMaximum);
+    QObject::connect(stepSpin, qOverload<int>(&QSpinBox::valueChanged), rangeSlider,
+                     &QSlider::setTickInterval);
+    QObject::connect(smallSpin, qOverload<int>(&QSpinBox::valueChanged), rangeSlider,
+                     &QSlider::setSingleStep);
 
     // --- 3. Slider with tick marks ---
     // Fix: Anchor to smallSpin because the property panel on the right is taller than the slider itself
@@ -295,7 +295,8 @@ TEST_F(SliderTest, VisualSliderGalleryLike) {
     QObject::connect(snapsTicks, &QRadioButton::toggled, [tickSlider](bool on) {
         if (on) {
             int interval = tickSlider->tickInterval();
-            if (interval <= 0) interval = 1;
+            if (interval <= 0)
+                interval = 1;
             tickSlider->setSingleStep(interval);
         }
     });
@@ -328,9 +329,10 @@ TEST_F(SliderTest, VisualSliderGalleryLike) {
     layout->addWidget(themeBtn);
 
     QObject::connect(themeBtn, &Button::clicked, []() {
-        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() == fluent::FluentElement::Light
-                                    ? fluent::FluentElement::Dark
-                                    : fluent::FluentElement::Light);
+        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() ==
+                                                fluent::FluentElement::Light
+                                            ? fluent::FluentElement::Dark
+                                            : fluent::FluentElement::Light);
     });
 
     scrollArea->show();

--- a/tests/components/collections/TestDataGrid.cpp
+++ b/tests/components/collections/TestDataGrid.cpp
@@ -62,8 +62,7 @@ void captureAccessibleModelEvent(QAccessibleEvent* event)
 struct ScopedAccessibleModelEventCapture {
     ScopedAccessibleModelEventCapture()
     {
-        previous = QAccessible::installUpdateHandler(
-            captureAccessibleModelEvent);
+        previous = QAccessible::installUpdateHandler(captureAccessibleModelEvent);
         g_accessibleModelEvents.clear();
     }
 
@@ -81,11 +80,8 @@ struct ScopedAccessibleModelEventCapture {
 class CountingTableModel final : public QAbstractTableModel {
 public:
     CountingTableModel(int rows, int columns, QObject* parent = nullptr)
-        : QAbstractTableModel(parent)
-        , m_rows(rows)
-        , m_columns(columns)
-    {
-    }
+        : QAbstractTableModel(parent), m_rows(rows), m_columns(columns)
+    {}
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
@@ -97,11 +93,10 @@ public:
         return parent.isValid() ? 0 : m_columns;
     }
 
-    QVariant data(const QModelIndex& index,
-                  int role = Qt::DisplayRole) const override
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
     {
-        if (!index.isValid() || index.row() < 0 || index.row() >= m_rows
-            || index.column() < 0 || index.column() >= m_columns) {
+        if (!index.isValid() || index.row() < 0 || index.row() >= m_rows || index.column() < 0 ||
+            index.column() >= m_columns) {
             return {};
         }
 
@@ -111,9 +106,7 @@ public:
         m_maximumObservedRow = std::max(m_maximumObservedRow, index.row());
 
         if (role == Qt::DisplayRole || role == Qt::EditRole) {
-            return QStringLiteral("R%1 C%2")
-                .arg(index.row())
-                .arg(index.column());
+            return QStringLiteral("R%1 C%2").arg(index.row()).arg(index.column());
         }
         return {};
     }
@@ -123,9 +116,8 @@ public:
     {
         if (role != Qt::DisplayRole)
             return {};
-        return orientation == Qt::Horizontal
-            ? QStringLiteral("Column %1").arg(section)
-            : QString::number(section + 1);
+        return orientation == Qt::Horizontal ? QStringLiteral("Column %1").arg(section)
+                                             : QString::number(section + 1);
     }
 
     Qt::ItemFlags flags(const QModelIndex& index) const override
@@ -151,8 +143,8 @@ public:
 private:
     static quint64 cellKey(const QModelIndex& index)
     {
-        return (static_cast<quint64>(static_cast<quint32>(index.row())) << 32)
-            | static_cast<quint32>(index.column());
+        return (static_cast<quint64>(static_cast<quint32>(index.row())) << 32) |
+               static_cast<quint32>(index.column());
     }
 
     int m_rows = 0;
@@ -174,8 +166,7 @@ public:
         QStyledItemDelegate::paint(painter, option, index);
     }
 
-    QWidget* createEditor(QWidget* parent,
-                          const QStyleOptionViewItem& option,
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
                           const QModelIndex& index) const override
     {
         QWidget* editor = QStyledItemDelegate::createEditor(parent, option, index);
@@ -184,13 +175,11 @@ public:
 
         ++m_createdEditorCount;
         m_activeEditors.insert(editor);
-        QObject::connect(
-            editor, &QObject::destroyed,
-            const_cast<CountingTableDelegate*>(this),
-            [this, editor]() {
-                m_activeEditors.remove(editor);
-                ++m_destroyedEditorCount;
-            });
+        QObject::connect(editor, &QObject::destroyed, const_cast<CountingTableDelegate*>(this),
+                         [this, editor]() {
+                             m_activeEditors.remove(editor);
+                             ++m_destroyedEditorCount;
+                         });
         return editor;
     }
 
@@ -211,8 +200,7 @@ class SortTrackingTableModel final : public QStandardItemModel {
 public:
     using QStandardItemModel::QStandardItemModel;
 
-    void sort(int column,
-              Qt::SortOrder order = Qt::AscendingOrder) override
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override
     {
         ++m_sortCallCount;
         m_lastSortColumn = column;
@@ -249,18 +237,15 @@ public:
         m_rejectionMessage = message;
     }
 
-    bool setData(const QModelIndex& index, const QVariant& value,
-                 int role = Qt::EditRole) override
+    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override
     {
         if (role == Qt::EditRole) {
             ++m_editAttempts;
             if (value.toString() == m_rejectedValue) {
-                QStandardItemModel::setData(
-                    index, m_rejectionMessage, kValidationMessageRole);
+                QStandardItemModel::setData(index, m_rejectionMessage, kValidationMessageRole);
                 return false;
             }
-            QStandardItemModel::setData(
-                index, QVariant(), kValidationMessageRole);
+            QStandardItemModel::setData(index, QVariant(), kValidationMessageRole);
         }
         return QStandardItemModel::setData(index, value, role);
     }
@@ -292,24 +277,20 @@ public:
         painter->restore();
     }
 
-    QWidget* createEditor(QWidget* parent,
-                          const QStyleOptionViewItem& option,
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
                           const QModelIndex& index) const override
     {
-        QWidget* editor =
-            QStyledItemDelegate::createEditor(parent, option, index);
+        QWidget* editor = QStyledItemDelegate::createEditor(parent, option, index);
         if (!editor)
             return nullptr;
 
         ++m_createdEditorCount;
         m_activeEditors.insert(editor);
-        QObject::connect(
-            editor, &QObject::destroyed,
-            const_cast<ValidationTrackingDelegate*>(this),
-            [this, editor] {
-                m_activeEditors.remove(editor);
-                ++m_destroyedEditorCount;
-            });
+        QObject::connect(editor, &QObject::destroyed, const_cast<ValidationTrackingDelegate*>(this),
+                         [this, editor] {
+                             m_activeEditors.remove(editor);
+                             ++m_destroyedEditorCount;
+                         });
         return editor;
     }
 
@@ -341,8 +322,7 @@ void showOffscreen(DataGrid* view, const QSize& size = QSize(800, 480))
     processEvents();
 }
 
-QLineEdit* beginKeyboardEdit(DataGrid* view,
-                             const QModelIndex& index)
+QLineEdit* beginKeyboardEdit(DataGrid* view, const QModelIndex& index)
 {
     if (!view || !index.isValid())
         return nullptr;
@@ -363,16 +343,14 @@ void renderViewport(DataGrid* view)
 
 int visibleCellCount(const DataGrid& view)
 {
-    if (!view.model() || view.model()->rowCount() == 0
-        || view.model()->columnCount() == 0) {
+    if (!view.model() || view.model()->rowCount() == 0 || view.model()->columnCount() == 0) {
         return 0;
     }
 
     const int firstRow = view.rowAt(0);
     const int lastRow = view.rowAt(std::max(0, view.viewport()->height() - 1));
     const int firstColumn = view.columnAt(0);
-    const int lastColumn = view.columnAt(
-        std::max(0, view.viewport()->width() - 1));
+    const int lastColumn = view.columnAt(std::max(0, view.viewport()->width() - 1));
     if (firstRow < 0 || firstColumn < 0)
         return 0;
 
@@ -382,8 +360,7 @@ int visibleCellCount(const DataGrid& view)
     return visibleRows * visibleColumns;
 }
 
-void expectViewportBounded(const DataGrid& view,
-                           const CountingTableModel& model,
+void expectViewportBounded(const DataGrid& view, const CountingTableModel& model,
                            const CountingTableDelegate& delegate)
 {
     const int visibleCells = visibleCellCount(view);
@@ -398,8 +375,7 @@ void expectViewportBounded(const DataGrid& view,
         << "Delegate painting must stay bounded around visible cells";
 }
 
-class DataGridVisualWindow final : public QWidget,
-                                   public fluent::FluentElement {
+class DataGridVisualWindow final : public QWidget, public fluent::FluentElement {
 public:
     DataGridVisualWindow()
     {
@@ -452,12 +428,11 @@ void populateVisualModel(QStandardItemModel* model)
             new QStandardItem(states.at(row % states.size())),
             new QStandardItem(
                 row % 5 == 0
-                    ? QStringLiteral("Waiting for a long localized dependency update / 正在等待依赖同步")
+                    ? QStringLiteral(
+                          "Waiting for a long localized dependency update / 正在等待依赖同步")
                     : QStringLiteral("Today, %1 minutes ago").arg(row + 2)),
             new QStandardItem(QStringLiteral("%1%").arg((row * 13) % 101)),
-            new QStandardItem(row % 3 == 0
-                                  ? QStringLiteral("High")
-                                  : QStringLiteral("Normal")),
+            new QStandardItem(row % 3 == 0 ? QStringLiteral("High") : QStringLiteral("Normal")),
         };
         if (row == 4) {
             for (QStandardItem* item : items)
@@ -478,14 +453,10 @@ protected:
         fluent::FluentElement::setTheme(fluent::FluentElement::Light);
     }
 
-    void TearDown() override
-    {
-        fluent::FluentElement::setTheme(m_previousTheme);
-    }
+    void TearDown() override { fluent::FluentElement::setTheme(m_previousTheme); }
 
 private:
-    fluent::FluentElement::Theme m_previousTheme =
-        fluent::FluentElement::Light;
+    fluent::FluentElement::Theme m_previousTheme = fluent::FluentElement::Light;
 };
 
 static_assert(std::is_base_of_v<QTableView, DataGrid>);
@@ -618,12 +589,10 @@ TEST_F(DataGridTest, Contract_CellWidgetsAndEditorsDoNotScaleWithModelSize)
     showOffscreen(&largeView);
 
     EXPECT_EQ(
-        smallView.viewport()->findChildren<QWidget*>(
-            QString(), Qt::FindDirectChildrenOnly).size(),
+        smallView.viewport()->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly).size(),
         0);
     EXPECT_EQ(
-        largeView.viewport()->findChildren<QWidget*>(
-            QString(), Qt::FindDirectChildrenOnly).size(),
+        largeView.viewport()->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly).size(),
         0);
     EXPECT_LE(largeView.findChildren<QWidget*>().size(),
               smallView.findChildren<QWidget*>().size() + 8)
@@ -639,8 +608,8 @@ TEST_F(DataGridTest, Contract_CellWidgetsAndEditorsDoNotScaleWithModelSize)
 
     ASSERT_EQ(largeDelegate.createdEditorCount(), 1);
     ASSERT_EQ(largeDelegate.activeEditorCount(), 1);
-    const auto editors = largeView.viewport()->findChildren<QLineEdit*>(
-        QString(), Qt::FindDirectChildrenOnly);
+    const auto editors =
+        largeView.viewport()->findChildren<QLineEdit*>(QString(), Qt::FindDirectChildrenOnly);
     ASSERT_EQ(editors.size(), 1);
 
     QTest::keyClick(editors.first(), Qt::Key_Escape);
@@ -653,8 +622,7 @@ TEST_F(DataGridTest, Contract_ModelAndDelegateRemainCallerOwned)
 {
     QPointer<CountingTableModel> model = new CountingTableModel(100000, 20);
     QPointer<CountingTableDelegate> delegate = new CountingTableDelegate;
-    QPointer<QItemSelectionModel> selectionModel =
-        new QItemSelectionModel(model);
+    QPointer<QItemSelectionModel> selectionModel = new QItemSelectionModel(model);
 
     auto view = std::make_unique<DataGrid>();
     view->setModel(model);
@@ -687,9 +655,8 @@ TEST_F(DataGridTest, Contract_ModelShapeHeadersAndEmptyStateStayLive)
     EXPECT_TRUE(view.isShowingPlaceholder());
     EXPECT_EQ(view.horizontalHeader()->count(), 3);
     EXPECT_EQ(view.verticalHeader()->count(), 0);
-    EXPECT_EQ(
-        model.headerData(2, Qt::Horizontal, Qt::DisplayRole).toString(),
-        QStringLiteral("Last updated — localized header / 最后更新时间"));
+    EXPECT_EQ(model.headerData(2, Qt::Horizontal, Qt::DisplayRole).toString(),
+              QStringLiteral("Last updated — localized header / 最后更新时间"));
 
     ASSERT_TRUE(model.insertRow(0));
     ASSERT_TRUE(model.setData(model.index(0, 0), QStringLiteral("Alpha")));
@@ -698,16 +665,13 @@ TEST_F(DataGridTest, Contract_ModelShapeHeadersAndEmptyStateStayLive)
 
     EXPECT_FALSE(view.isShowingPlaceholder());
     EXPECT_EQ(view.verticalHeader()->count(), 1);
-    EXPECT_EQ(view.model()->index(0, 0).data().toString(),
-              QStringLiteral("Alpha"));
+    EXPECT_EQ(view.model()->index(0, 0).data().toString(), QStringLiteral("Alpha"));
 
     ASSERT_TRUE(model.insertColumn(1));
-    ASSERT_TRUE(model.setHeaderData(
-        1, Qt::Horizontal, QStringLiteral("Status"), Qt::DisplayRole));
+    ASSERT_TRUE(model.setHeaderData(1, Qt::Horizontal, QStringLiteral("Status"), Qt::DisplayRole));
     processEvents();
     EXPECT_EQ(view.horizontalHeader()->count(), 4);
-    EXPECT_EQ(model.headerData(1, Qt::Horizontal).toString(),
-              QStringLiteral("Status"));
+    EXPECT_EQ(model.headerData(1, Qt::Horizontal).toString(), QStringLiteral("Status"));
 
     ASSERT_TRUE(model.removeColumn(1));
     ASSERT_TRUE(model.removeRow(0));
@@ -717,8 +681,7 @@ TEST_F(DataGridTest, Contract_ModelShapeHeadersAndEmptyStateStayLive)
     EXPECT_TRUE(view.isShowingPlaceholder());
 
     QStandardItemModel replacement(2, 2);
-    replacement.setHorizontalHeaderLabels(
-        {QStringLiteral("Key"), QStringLiteral("Value")});
+    replacement.setHorizontalHeaderLabels({QStringLiteral("Key"), QStringLiteral("Value")});
     view.setModel(&replacement);
     processEvents();
     EXPECT_EQ(view.model(), &replacement);
@@ -742,8 +705,7 @@ TEST_F(DataGridTest, Contract_SelectionModesAndKeyboardStayModelDriven)
     QStandardItemModel model(4, 3);
     for (int row = 0; row < model.rowCount(); ++row) {
         for (int column = 0; column < model.columnCount(); ++column) {
-            model.setData(model.index(row, column),
-                          QStringLiteral("%1,%2").arg(row).arg(column));
+            model.setData(model.index(row, column), QStringLiteral("%1,%2").arg(row).arg(column));
         }
     }
 
@@ -754,18 +716,14 @@ TEST_F(DataGridTest, Contract_SelectionModesAndKeyboardStayModelDriven)
     using FluentSelectionMode = fluent::collections::SelectionMode;
     view.setSelectionMode(FluentSelectionMode::None);
     EXPECT_EQ(view.selectionMode(), FluentSelectionMode::None);
-    EXPECT_EQ(view.QAbstractItemView::selectionMode(),
-              QAbstractItemView::NoSelection);
+    EXPECT_EQ(view.QAbstractItemView::selectionMode(), QAbstractItemView::NoSelection);
 
     view.setSelectionMode(FluentSelectionMode::Single);
-    EXPECT_EQ(view.QAbstractItemView::selectionMode(),
-              QAbstractItemView::SingleSelection);
+    EXPECT_EQ(view.QAbstractItemView::selectionMode(), QAbstractItemView::SingleSelection);
     view.setSelectionMode(FluentSelectionMode::Multiple);
-    EXPECT_EQ(view.QAbstractItemView::selectionMode(),
-              QAbstractItemView::MultiSelection);
+    EXPECT_EQ(view.QAbstractItemView::selectionMode(), QAbstractItemView::MultiSelection);
     view.setSelectionMode(FluentSelectionMode::Extended);
-    EXPECT_EQ(view.QAbstractItemView::selectionMode(),
-              QAbstractItemView::ExtendedSelection);
+    EXPECT_EQ(view.QAbstractItemView::selectionMode(), QAbstractItemView::ExtendedSelection);
 
     view.setSelectionBehavior(QAbstractItemView::SelectItems);
     view.setCurrentIndex(model.index(0, 0));
@@ -776,14 +734,12 @@ TEST_F(DataGridTest, Contract_SelectionModesAndKeyboardStayModelDriven)
     EXPECT_EQ(view.currentIndex(), model.index(1, 1));
 
     view.setSelectionBehavior(QAbstractItemView::SelectRows);
-    view.selectionModel()->select(
-        model.index(2, 1),
-        QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    view.selectionModel()->select(model.index(2, 1),
+                                  QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
     const QModelIndexList selectedRows = view.selectionModel()->selectedRows();
     ASSERT_EQ(selectedRows.size(), 1);
     EXPECT_EQ(selectedRows.first().row(), 2);
-    EXPECT_EQ(view.selectionModel()->selectedIndexes().size(),
-              model.columnCount());
+    EXPECT_EQ(view.selectionModel()->selectedIndexes().size(), model.columnCount());
 
     view.setLayoutDirection(Qt::RightToLeft);
     EXPECT_EQ(view.layoutDirection(), Qt::RightToLeft);
@@ -805,8 +761,7 @@ TEST_F(DataGridTest, Contract_ReadOnlyDefaultsAndThemePaletteUseTokens)
     EXPECT_TRUE(view.hasMouseTracking());
     EXPECT_TRUE(view.viewport()->hasMouseTracking());
     EXPECT_EQ(view.focusPolicy(), Qt::StrongFocus);
-    EXPECT_EQ(view.horizontalHeader()->sectionResizeMode(0),
-              QHeaderView::Interactive);
+    EXPECT_EQ(view.horizontalHeader()->sectionResizeMode(0), QHeaderView::Interactive);
     EXPECT_TRUE(view.horizontalHeader()->sectionsMovable());
     EXPECT_EQ(view.verticalHeader()->sectionResizeMode(0), QHeaderView::Fixed);
     EXPECT_EQ(view.horizontalHeader()->minimumHeight(), 36);
@@ -816,12 +771,9 @@ TEST_F(DataGridTest, Contract_ReadOnlyDefaultsAndThemePaletteUseTokens)
 
     const QColor lightBase = view.themeColorsRef().bgLayer;
     EXPECT_EQ(view.palette().color(QPalette::Base), lightBase);
-    EXPECT_EQ(view.palette().color(QPalette::AlternateBase),
-              view.themeColorsRef().bgLayer);
-    EXPECT_EQ(view.palette().color(QPalette::Highlight),
-              view.themeColorsRef().subtleSecondary);
-    EXPECT_EQ(view.palette().color(QPalette::HighlightedText),
-              view.themeColorsRef().textPrimary);
+    EXPECT_EQ(view.palette().color(QPalette::AlternateBase), view.themeColorsRef().bgLayer);
+    EXPECT_EQ(view.palette().color(QPalette::Highlight), view.themeColorsRef().subtleSecondary);
+    EXPECT_EQ(view.palette().color(QPalette::HighlightedText), view.themeColorsRef().textPrimary);
     EXPECT_EQ(view.palette().color(QPalette::Disabled, QPalette::Text),
               view.themeColorsRef().textDisabled);
 
@@ -835,12 +787,9 @@ TEST_F(DataGridTest, Contract_ReadOnlyDefaultsAndThemePaletteUseTokens)
     processEvents();
 
     EXPECT_EQ(view.effectiveTheme(), fluent::FluentElement::Dark);
-    EXPECT_EQ(view.palette().color(QPalette::Base),
-              view.themeColorsRef().bgLayer);
-    EXPECT_EQ(view.palette().color(QPalette::AlternateBase),
-              view.themeColorsRef().bgLayer);
-    EXPECT_EQ(view.palette().color(QPalette::Highlight),
-              view.themeColorsRef().subtleSecondary);
+    EXPECT_EQ(view.palette().color(QPalette::Base), view.themeColorsRef().bgLayer);
+    EXPECT_EQ(view.palette().color(QPalette::AlternateBase), view.themeColorsRef().bgLayer);
+    EXPECT_EQ(view.palette().color(QPalette::Highlight), view.themeColorsRef().subtleSecondary);
     EXPECT_EQ(view.palette().color(QPalette::Disabled, QPalette::Text),
               view.themeColorsRef().textDisabled);
     EXPECT_NE(view.palette().color(QPalette::Base), lightBase);
@@ -887,32 +836,26 @@ TEST_F(DataGridTest, Contract_FluentScrollBarsMirrorAndChainAtBoundaries)
     view.setScrollChainingEnabled(true);
     view.verticalScrollBar()->setValue(view.verticalScrollBar()->minimum());
     const QPoint wheelPoint = view.viewport()->rect().center();
-    FLUENT_MAKE_WHEEL_EVENT(
-        chainedWheel, wheelPoint.x(), wheelPoint.y(), 120, Qt::NoModifier);
+    FLUENT_MAKE_WHEEL_EVENT(chainedWheel, wheelPoint.x(), wheelPoint.y(), 120, Qt::NoModifier);
     chainedWheel.setAccepted(false);
     QApplication::sendEvent(view.viewport(), &chainedWheel);
     EXPECT_FALSE(chainedWheel.isAccepted());
-    EXPECT_EQ(view.verticalScrollBar()->value(),
-              view.verticalScrollBar()->minimum());
+    EXPECT_EQ(view.verticalScrollBar()->value(), view.verticalScrollBar()->minimum());
 
-    FLUENT_MAKE_WHEEL_EVENT(
-        containedWheel, wheelPoint.x(), wheelPoint.y(), -120, Qt::NoModifier);
+    FLUENT_MAKE_WHEEL_EVENT(containedWheel, wheelPoint.x(), wheelPoint.y(), -120, Qt::NoModifier);
     containedWheel.setAccepted(false);
     QApplication::sendEvent(view.viewport(), &containedWheel);
     EXPECT_TRUE(containedWheel.isAccepted());
-    EXPECT_GT(view.verticalScrollBar()->value(),
-              view.verticalScrollBar()->minimum());
+    EXPECT_GT(view.verticalScrollBar()->value(), view.verticalScrollBar()->minimum());
     EXPECT_EQ(vertical->value(), view.verticalScrollBar()->value());
 
     view.verticalScrollBar()->setValue(view.verticalScrollBar()->maximum());
-    FLUENT_MAKE_WHEEL_EVENT(
-        bottomChainedWheel, wheelPoint.x(), wheelPoint.y(), -120,
-        Qt::NoModifier);
+    FLUENT_MAKE_WHEEL_EVENT(bottomChainedWheel, wheelPoint.x(), wheelPoint.y(), -120,
+                            Qt::NoModifier);
     bottomChainedWheel.setAccepted(false);
     QApplication::sendEvent(view.viewport(), &bottomChainedWheel);
     EXPECT_FALSE(bottomChainedWheel.isAccepted());
-    EXPECT_EQ(view.verticalScrollBar()->value(),
-              view.verticalScrollBar()->maximum());
+    EXPECT_EQ(view.verticalScrollBar()->value(), view.verticalScrollBar()->maximum());
 
     CountingTableModel fittedModel(2, 2);
     DataGrid fittedView;
@@ -921,12 +864,10 @@ TEST_F(DataGridTest, Contract_FluentScrollBarsMirrorAndChainAtBoundaries)
     showOffscreen(&fittedView, QSize(360, 180));
     fittedView.doItemsLayout();
     processEvents();
-    ASSERT_EQ(fittedView.verticalScrollBar()->minimum(),
-              fittedView.verticalScrollBar()->maximum());
+    ASSERT_EQ(fittedView.verticalScrollBar()->minimum(), fittedView.verticalScrollBar()->maximum());
     const QPoint fittedWheelPoint = fittedView.viewport()->rect().center();
-    FLUENT_MAKE_WHEEL_EVENT(
-        fittedChainedWheel, fittedWheelPoint.x(), fittedWheelPoint.y(), -120,
-        Qt::NoModifier);
+    FLUENT_MAKE_WHEEL_EVENT(fittedChainedWheel, fittedWheelPoint.x(), fittedWheelPoint.y(), -120,
+                            Qt::NoModifier);
     fittedChainedWheel.setAccepted(false);
     QApplication::sendEvent(fittedView.viewport(), &fittedChainedWheel);
     EXPECT_FALSE(fittedChainedWheel.isAccepted());
@@ -963,8 +904,7 @@ TEST_F(DataGridTest, Contract_ColumnInteractionUsesHeaderAndModelAuthority)
     header->moveSection(header->visualIndex(2), 0);
     EXPECT_EQ(header->visualIndex(2), 0);
     EXPECT_EQ(header->logicalIndex(0), 2);
-    EXPECT_EQ(model.headerData(2, Qt::Horizontal).toString(),
-              QStringLiteral("Priority"));
+    EXPECT_EQ(model.headerData(2, Qt::Horizontal).toString(), QStringLiteral("Priority"));
 
     view.setColumnHidden(1, true);
     EXPECT_TRUE(view.isColumnHidden(1));
@@ -1009,8 +949,7 @@ TEST_F(DataGridTest, Contract_EditingDefaultDelegateCommitsCancelsAndTabs)
     QTest::keyClick(committedEditor, Qt::Key_Return);
     processEvents();
 
-    EXPECT_EQ(model.data(first, Qt::EditRole).toString(),
-              QStringLiteral("Committed"));
+    EXPECT_EQ(model.data(first, Qt::EditRole).toString(), QStringLiteral("Committed"));
     EXPECT_TRUE(committedEditor.isNull());
 
     QPointer<QLineEdit> cancelledEditor = beginKeyboardEdit(&view, first);
@@ -1019,8 +958,7 @@ TEST_F(DataGridTest, Contract_EditingDefaultDelegateCommitsCancelsAndTabs)
     QTest::keyClick(cancelledEditor, Qt::Key_Escape);
     processEvents();
 
-    EXPECT_EQ(model.data(first, Qt::EditRole).toString(),
-              QStringLiteral("Committed"));
+    EXPECT_EQ(model.data(first, Qt::EditRole).toString(), QStringLiteral("Committed"));
     EXPECT_TRUE(cancelledEditor.isNull());
 
     QPointer<QLineEdit> tabEditor = beginKeyboardEdit(&view, first);
@@ -1029,8 +967,7 @@ TEST_F(DataGridTest, Contract_EditingDefaultDelegateCommitsCancelsAndTabs)
     QTest::keyClick(tabEditor, Qt::Key_Tab);
     processEvents();
 
-    EXPECT_EQ(model.data(first, Qt::EditRole).toString(),
-              QStringLiteral("Tab committed"));
+    EXPECT_EQ(model.data(first, Qt::EditRole).toString(), QStringLiteral("Tab committed"));
     EXPECT_EQ(view.currentIndex(), model.index(0, 1));
     EXPECT_TRUE(tabEditor.isNull());
 
@@ -1050,9 +987,8 @@ TEST_F(DataGridTest, Contract_EditingModelRejectionKeepsValuesAndDelegateValidat
     EditAuthorityModel model(1, 1);
     const QModelIndex index = model.index(0, 0);
     model.setData(index, QStringLiteral("Accepted"), Qt::EditRole);
-    model.rejectValue(
-        QStringLiteral("reject"),
-        QStringLiteral("Value is rejected by the application model"));
+    model.rejectValue(QStringLiteral("reject"),
+                      QStringLiteral("Value is rejected by the application model"));
     const int baselineAttempts = model.editAttempts();
 
     ValidationTrackingDelegate delegate;
@@ -1070,10 +1006,8 @@ TEST_F(DataGridTest, Contract_EditingModelRejectionKeepsValuesAndDelegateValidat
     processEvents();
 
     EXPECT_EQ(model.editAttempts(), baselineAttempts + 1);
-    EXPECT_EQ(model.data(index, Qt::DisplayRole).toString(),
-              QStringLiteral("Accepted"));
-    EXPECT_EQ(model.data(index, Qt::EditRole).toString(),
-              QStringLiteral("Accepted"));
+    EXPECT_EQ(model.data(index, Qt::DisplayRole).toString(), QStringLiteral("Accepted"));
+    EXPECT_EQ(model.data(index, Qt::EditRole).toString(), QStringLiteral("Accepted"));
     EXPECT_EQ(model.data(index, kValidationMessageRole).toString(),
               QStringLiteral("Value is rejected by the application model"));
     EXPECT_TRUE(rejectedEditor.isNull());
@@ -1082,8 +1016,7 @@ TEST_F(DataGridTest, Contract_EditingModelRejectionKeepsValuesAndDelegateValidat
 
     renderViewport(&view);
     EXPECT_GT(delegate.validationPaintCount(), 0);
-    EXPECT_EQ(model.data(index, Qt::DisplayRole).toString(),
-              QStringLiteral("Accepted"))
+    EXPECT_EQ(model.data(index, Qt::DisplayRole).toString(), QStringLiteral("Accepted"))
         << "Validation presentation must not rewrite display data";
 
     QPointer<QLineEdit> acceptedEditor = beginKeyboardEdit(&view, index);
@@ -1092,8 +1025,7 @@ TEST_F(DataGridTest, Contract_EditingModelRejectionKeepsValuesAndDelegateValidat
     QTest::keyClick(acceptedEditor, Qt::Key_Return);
     processEvents();
 
-    EXPECT_EQ(model.data(index, Qt::EditRole).toString(),
-              QStringLiteral("Updated"));
+    EXPECT_EQ(model.data(index, Qt::EditRole).toString(), QStringLiteral("Updated"));
     EXPECT_TRUE(model.data(index, kValidationMessageRole).toString().isEmpty());
     EXPECT_TRUE(acceptedEditor.isNull());
     EXPECT_EQ(delegate.createdEditorCount(), 2);
@@ -1105,8 +1037,7 @@ TEST_F(DataGridTest, Contract_EditingLifecycleClosesTransientEditors)
     QStandardItemModel original(2, 2);
     original.setData(original.index(0, 0), QStringLiteral("Original"));
     QStandardItemModel replacement(1, 1);
-    replacement.setData(
-        replacement.index(0, 0), QStringLiteral("Replacement"));
+    replacement.setData(replacement.index(0, 0), QStringLiteral("Replacement"));
 
     CountingTableDelegate delegate;
     auto view = std::make_unique<DataGrid>();
@@ -1115,8 +1046,7 @@ TEST_F(DataGridTest, Contract_EditingLifecycleClosesTransientEditors)
     view->setEditTriggers(QAbstractItemView::EditKeyPressed);
     showOffscreen(view.get(), QSize(420, 220));
 
-    QPointer<QLineEdit> resetEditor =
-        beginKeyboardEdit(view.get(), original.index(0, 0));
+    QPointer<QLineEdit> resetEditor = beginKeyboardEdit(view.get(), original.index(0, 0));
     ASSERT_FALSE(resetEditor.isNull());
     EXPECT_EQ(delegate.activeEditorCount(), 1);
     original.clear();
@@ -1127,24 +1057,21 @@ TEST_F(DataGridTest, Contract_EditingLifecycleClosesTransientEditors)
     original.setRowCount(1);
     original.setColumnCount(1);
     original.setData(original.index(0, 0), QStringLiteral("Restored"));
-    QPointer<QLineEdit> replacementEditor =
-        beginKeyboardEdit(view.get(), original.index(0, 0));
+    QPointer<QLineEdit> replacementEditor = beginKeyboardEdit(view.get(), original.index(0, 0));
     ASSERT_FALSE(replacementEditor.isNull());
     view->setModel(&replacement);
     processEvents();
     EXPECT_TRUE(replacementEditor.isNull());
     EXPECT_EQ(delegate.activeEditorCount(), 0);
 
-    QPointer<QLineEdit> destructionEditor =
-        beginKeyboardEdit(view.get(), replacement.index(0, 0));
+    QPointer<QLineEdit> destructionEditor = beginKeyboardEdit(view.get(), replacement.index(0, 0));
     ASSERT_FALSE(destructionEditor.isNull());
     EXPECT_EQ(delegate.activeEditorCount(), 1);
     view.reset();
     processEvents();
     EXPECT_TRUE(destructionEditor.isNull());
     EXPECT_EQ(delegate.activeEditorCount(), 0);
-    EXPECT_EQ(delegate.createdEditorCount(),
-              delegate.destroyedEditorCount());
+    EXPECT_EQ(delegate.createdEditorCount(), delegate.destroyedEditorCount());
 }
 
 TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
@@ -1162,8 +1089,8 @@ TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
     });
     for (int row = 0; row < model.rowCount(); ++row) {
         for (int column = 0; column < model.columnCount(); ++column) {
-            QStandardItem* item = new QStandardItem(
-                QStringLiteral("Cell %1,%2").arg(row).arg(column));
+            QStandardItem* item =
+                new QStandardItem(QStringLiteral("Cell %1,%2").arg(row).arg(column));
             item->setEditable(false);
             model.setItem(row, column, item);
         }
@@ -1171,18 +1098,15 @@ TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
 
     DataGrid view;
     view.setAccessibleName(QStringLiteral("Project portfolio"));
-    view.setAccessibleDescription(
-        QStringLiteral("Application-owned project summary"));
+    view.setAccessibleDescription(QStringLiteral("Application-owned project summary"));
     view.setModel(&model);
     view.setSelectionBehavior(QAbstractItemView::SelectRows);
     showOffscreen(&view, QSize(520, 240));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     EXPECT_EQ(root->role(), QAccessible::Table);
-    EXPECT_EQ(root->text(QAccessible::Name),
-              QStringLiteral("Project portfolio"));
+    EXPECT_EQ(root->text(QAccessible::Name), QStringLiteral("Project portfolio"));
     EXPECT_EQ(root->text(QAccessible::Description),
               QStringLiteral("Application-owned project summary"));
     EXPECT_FALSE(root->state().disabled);
@@ -1205,18 +1129,14 @@ TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
     EXPECT_EQ(cellInfo->columnExtent(), 1);
     EXPECT_EQ(cellInfo->table(), root);
 
-    const QList<QAccessibleInterface*> columnHeaders =
-        cellInfo->columnHeaderCells();
-    const QList<QAccessibleInterface*> rowHeaders =
-        cellInfo->rowHeaderCells();
+    const QList<QAccessibleInterface*> columnHeaders = cellInfo->columnHeaderCells();
+    const QList<QAccessibleInterface*> rowHeaders = cellInfo->rowHeaderCells();
     ASSERT_EQ(columnHeaders.size(), 1);
     ASSERT_EQ(rowHeaders.size(), 1);
     EXPECT_EQ(columnHeaders.first()->role(), QAccessible::ColumnHeader);
-    EXPECT_EQ(columnHeaders.first()->text(QAccessible::Name),
-              QStringLiteral("Status"));
+    EXPECT_EQ(columnHeaders.first()->text(QAccessible::Name), QStringLiteral("Status"));
     EXPECT_EQ(rowHeaders.first()->role(), QAccessible::RowHeader);
-    EXPECT_EQ(rowHeaders.first()->text(QAccessible::Name),
-              QStringLiteral("Row 2"));
+    EXPECT_EQ(rowHeaders.first()->text(QAccessible::Name), QStringLiteral("Row 2"));
 
     view.selectRow(1);
     view.setCurrentIndex(model.index(1, 2));
@@ -1237,8 +1157,7 @@ TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
     ASSERT_NE(actionCell, nullptr);
     QAccessibleActionInterface* action = actionCell->actionInterface();
     ASSERT_NE(action, nullptr);
-    EXPECT_TRUE(action->actionNames().contains(
-        QAccessibleActionInterface::toggleAction()));
+    EXPECT_TRUE(action->actionNames().contains(QAccessibleActionInterface::toggleAction()));
     action->doAction(QAccessibleActionInterface::toggleAction());
     processEvents();
     EXPECT_TRUE(table->isRowSelected(2));
@@ -1247,8 +1166,7 @@ TEST_F(DataGridTest, Contract_AccessibilityUsesNativeLogicalTableSemantics)
     fluent::FluentElement::setTheme(fluent::FluentElement::Dark);
     model.setHeaderData(2, Qt::Horizontal, QStringLiteral("State"));
     processEvents();
-    EXPECT_EQ(root->text(QAccessible::Name),
-              QStringLiteral("Project portfolio"));
+    EXPECT_EQ(root->text(QAccessible::Name), QStringLiteral("Project portfolio"));
     EXPECT_EQ(root->text(QAccessible::Description),
               QStringLiteral("Application-owned project summary"));
     EXPECT_EQ(table->columnDescription(2), QStringLiteral("State"));
@@ -1275,8 +1193,7 @@ TEST_F(DataGridTest, Contract_AccessibilityReadOnlyStateFollowsViewAndModel)
     view.setModel(&model);
     showOffscreen(&view, QSize(420, 220));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     QAccessibleTableInterface* table = root->tableInterface();
     ASSERT_NE(table, nullptr);
@@ -1301,8 +1218,7 @@ TEST_F(DataGridTest, Contract_AccessibilityReadOnlyStateFollowsViewAndModel)
         << "NoEditTriggers keeps an otherwise editable model cell read-only";
     EXPECT_FALSE(editableCell->state().editable);
 
-    view.setEditTriggers(QAbstractItemView::DoubleClicked
-                         | QAbstractItemView::EditKeyPressed);
+    view.setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
     processEvents();
 
     EXPECT_FALSE(root->state().readOnly);
@@ -1334,12 +1250,10 @@ TEST_F(DataGridTest, Contract_AccessibilityLogicalCacheFollowsViewLifetime)
         view->setModel(&model);
         showOffscreen(view.get(), QSize(420, 220));
 
-        QAccessibleInterface* root =
-            QAccessible::queryAccessibleInterface(view.get());
+        QAccessibleInterface* root = QAccessible::queryAccessibleInterface(view.get());
         ASSERT_NE(root, nullptr);
         ASSERT_NE(root->tableInterface(), nullptr);
-        QAccessibleInterface* cell =
-            root->tableInterface()->cellAt(1, 1);
+        QAccessibleInterface* cell = root->tableInterface()->cellAt(1, 1);
         ASSERT_NE(cell, nullptr);
         rootId = QAccessible::uniqueId(root);
         cellId = QAccessible::uniqueId(cell);
@@ -1358,56 +1272,43 @@ TEST_F(DataGridTest, Contract_AccessibilityPrefersModelSemanticText)
     QStandardItemModel model(1, 1);
     const QModelIndex index = model.index(0, 0);
     model.setData(index, QStringLiteral("Visible project"), Qt::DisplayRole);
-    model.setData(index, QStringLiteral("Accessible project name"),
-                  Qt::AccessibleTextRole);
+    model.setData(index, QStringLiteral("Accessible project name"), Qt::AccessibleTextRole);
     model.setData(index, QStringLiteral("Accessible project summary"),
                   Qt::AccessibleDescriptionRole);
-    model.setHeaderData(0, Qt::Horizontal,
-                        QStringLiteral("Visible project column"));
-    model.setHeaderData(0, Qt::Horizontal,
-                        QStringLiteral("Accessible project column"),
+    model.setHeaderData(0, Qt::Horizontal, QStringLiteral("Visible project column"));
+    model.setHeaderData(0, Qt::Horizontal, QStringLiteral("Accessible project column"),
                         Qt::AccessibleTextRole);
 
     DataGrid view;
     view.setModel(&model);
     showOffscreen(&view, QSize(420, 220));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     QAccessibleTableInterface* table = root->tableInterface();
     ASSERT_NE(table, nullptr);
     QAccessibleInterface* cell = table->cellAt(0, 0);
     ASSERT_NE(cell, nullptr);
 
-    EXPECT_EQ(index.data(Qt::DisplayRole).toString(),
-              QStringLiteral("Visible project"));
-    EXPECT_EQ(cell->text(QAccessible::Name),
-              QStringLiteral("Accessible project name"));
-    EXPECT_EQ(cell->text(QAccessible::Description),
-              QStringLiteral("Accessible project summary"));
-    EXPECT_EQ(table->columnDescription(0),
-              QStringLiteral("Visible project column"));
+    EXPECT_EQ(index.data(Qt::DisplayRole).toString(), QStringLiteral("Visible project"));
+    EXPECT_EQ(cell->text(QAccessible::Name), QStringLiteral("Accessible project name"));
+    EXPECT_EQ(cell->text(QAccessible::Description), QStringLiteral("Accessible project summary"));
+    EXPECT_EQ(table->columnDescription(0), QStringLiteral("Visible project column"));
     QAccessibleTableCellInterface* cellInfo = cell->tableCellInterface();
     ASSERT_NE(cellInfo, nullptr);
-    const QList<QAccessibleInterface*> columnHeaders =
-        cellInfo->columnHeaderCells();
+    const QList<QAccessibleInterface*> columnHeaders = cellInfo->columnHeaderCells();
     ASSERT_EQ(columnHeaders.size(), 1);
     EXPECT_EQ(columnHeaders.first()->text(QAccessible::Name),
               QStringLiteral("Accessible project column"));
 
     model.setData(index, QStringLiteral("Renamed for assistive technology"),
                   Qt::AccessibleTextRole);
-    model.setData(index, QStringLiteral("Updated semantic summary"),
-                  Qt::AccessibleDescriptionRole);
+    model.setData(index, QStringLiteral("Updated semantic summary"), Qt::AccessibleDescriptionRole);
     processEvents();
 
-    EXPECT_EQ(index.data(Qt::DisplayRole).toString(),
-              QStringLiteral("Visible project"));
-    EXPECT_EQ(cell->text(QAccessible::Name),
-              QStringLiteral("Renamed for assistive technology"));
-    EXPECT_EQ(cell->text(QAccessible::Description),
-              QStringLiteral("Updated semantic summary"));
+    EXPECT_EQ(index.data(Qt::DisplayRole).toString(), QStringLiteral("Visible project"));
+    EXPECT_EQ(cell->text(QAccessible::Name), QStringLiteral("Renamed for assistive technology"));
+    EXPECT_EQ(cell->text(QAccessible::Description), QStringLiteral("Updated semantic summary"));
 }
 
 TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
@@ -1420,9 +1321,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
     for (int row = 0; row < model.rowCount(); ++row) {
         for (int column = 0; column < model.columnCount(); ++column) {
             model.setData(model.index(row, column),
-                          QStringLiteral("Original %1,%2")
-                              .arg(row)
-                              .arg(column));
+                          QStringLiteral("Original %1,%2").arg(row).arg(column));
         }
     }
 
@@ -1430,8 +1329,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
     view.setModel(&model);
     showOffscreen(&view, QSize(420, 220));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     QAccessibleTableInterface* table = root->tableInterface();
     ASSERT_NE(table, nullptr);
@@ -1444,8 +1342,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
     processEvents();
 
     EXPECT_EQ(table->rowCount(), 2);
-    QAccessibleInterface* staleRemovedCell =
-        QAccessible::accessibleInterface(removedCellId);
+    QAccessibleInterface* staleRemovedCell = QAccessible::accessibleInterface(removedCellId);
     EXPECT_TRUE(!staleRemovedCell || !staleRemovedCell->isValid());
 
     ASSERT_TRUE(model.insertRow(0));
@@ -1456,17 +1353,13 @@ TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
     EXPECT_EQ(table->rowCount(), 3);
     QAccessibleInterface* insertedCell = table->cellAt(0, 1);
     ASSERT_NE(insertedCell, nullptr);
-    EXPECT_EQ(insertedCell->text(QAccessible::Name),
-              QStringLiteral("Inserted owner"));
-    const QAccessible::Id originalModelCellId =
-        QAccessible::uniqueId(insertedCell);
+    EXPECT_EQ(insertedCell->text(QAccessible::Name), QStringLiteral("Inserted owner"));
+    const QAccessible::Id originalModelCellId = QAccessible::uniqueId(insertedCell);
 
     QStandardItemModel replacement(2, 1);
     replacement.setHorizontalHeaderLabels({QStringLiteral("Replacement")});
-    replacement.setData(replacement.index(0, 0),
-                        QStringLiteral("Replacement row 1"));
-    replacement.setData(replacement.index(1, 0),
-                        QStringLiteral("Replacement row 2"));
+    replacement.setData(replacement.index(0, 0), QStringLiteral("Replacement row 1"));
+    replacement.setData(replacement.index(1, 0), QStringLiteral("Replacement row 2"));
     view.setModel(&replacement);
     processEvents();
 
@@ -1478,8 +1371,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelChangesInvalidateCachedCells)
     EXPECT_TRUE(!staleOriginalModelCell || !staleOriginalModelCell->isValid());
     QAccessibleInterface* replacementCell = table->cellAt(1, 0);
     ASSERT_NE(replacementCell, nullptr);
-    EXPECT_EQ(replacementCell->text(QAccessible::Name),
-              QStringLiteral("Replacement row 2"));
+    EXPECT_EQ(replacementCell->text(QAccessible::Name), QStringLiteral("Replacement row 2"));
     EXPECT_EQ(view.findChildren<QWidget*>().size(), widgetCount);
 }
 
@@ -1497,8 +1389,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelReplacementEmitsOneReset)
     view.setModel(&original);
     showOffscreen(&view, QSize(420, 220));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     ASSERT_NE(root->tableInterface(), nullptr);
     ASSERT_NE(root->tableInterface()->cellAt(0, 0), nullptr);
@@ -1510,8 +1401,7 @@ TEST_F(DataGridTest, Contract_AccessibilityModelReplacementEmitsOneReset)
 
     ASSERT_EQ(g_accessibleModelEvents.size(), 1);
     EXPECT_EQ(g_accessibleModelEvents.first().object, &view);
-    EXPECT_EQ(g_accessibleModelEvents.first().type,
-              QAccessible::TableModelChanged);
+    EXPECT_EQ(g_accessibleModelEvents.first().type, QAccessible::TableModelChanged);
     EXPECT_EQ(g_accessibleModelEvents.first().modelChangeType,
               QAccessibleTableModelChangeEvent::ModelReset);
 
@@ -1530,13 +1420,11 @@ TEST_F(DataGridTest, Contract_AccessibilityEmptyStatePreservesCallerText)
     view.setModel(&model);
     showOffscreen(&view, QSize(420, 220));
 
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     QAccessibleTableInterface* table = root->tableInterface();
     ASSERT_NE(table, nullptr);
-    EXPECT_EQ(root->text(QAccessible::Description),
-              QStringLiteral("No project records"));
+    EXPECT_EQ(root->text(QAccessible::Description), QStringLiteral("No project records"));
     EXPECT_EQ(table->rowCount(), 0);
     EXPECT_EQ(table->columnCount(), 2);
 
@@ -1549,8 +1437,7 @@ TEST_F(DataGridTest, Contract_AccessibilityEmptyStatePreservesCallerText)
     ASSERT_TRUE(model.removeRow(0));
     view.setPlaceholderText(QStringLiteral("No matching projects"));
     processEvents();
-    EXPECT_EQ(root->text(QAccessible::Description),
-              QStringLiteral("Caller summary"));
+    EXPECT_EQ(root->text(QAccessible::Description), QStringLiteral("Caller summary"));
     EXPECT_EQ(table->rowCount(), 0);
 }
 
@@ -1563,8 +1450,7 @@ TEST_F(DataGridTest, Contract_AccessibilityLargeModelStaysLogicalWithoutCellWidg
 
     const int widgetCount = view.findChildren<QWidget*>().size();
     model.resetObservations();
-    QAccessibleInterface* root =
-        QAccessible::queryAccessibleInterface(&view);
+    QAccessibleInterface* root = QAccessible::queryAccessibleInterface(&view);
     ASSERT_NE(root, nullptr);
     QAccessibleTableInterface* table = root->tableInterface();
     ASSERT_NE(table, nullptr);
@@ -1581,8 +1467,7 @@ TEST_F(DataGridTest, Contract_AccessibilityLargeModelStaysLogicalWithoutCellWidg
 
     QAccessibleInterface* lastCell = table->cellAt(99999, 19);
     ASSERT_NE(lastCell, nullptr);
-    EXPECT_EQ(lastCell->text(QAccessible::Name),
-              QStringLiteral("R99999 C19"));
+    EXPECT_EQ(lastCell->text(QAccessible::Name), QStringLiteral("R99999 C19"));
     ASSERT_NE(lastCell->tableCellInterface(), nullptr);
     EXPECT_EQ(lastCell->tableCellInterface()->rowIndex(), 99999);
     EXPECT_EQ(lastCell->tableCellInterface()->columnIndex(), 19);
@@ -1596,13 +1481,12 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
     if (qEnvironmentVariableIsSet("SKIP_VISUAL_TEST")) {
         GTEST_SKIP() << "Set SKIP_VISUAL_TEST=1 to skip visual tests";
     }
-    if (qEnvironmentVariableIsSet("QT_QPA_PLATFORM")
-        && qEnvironmentVariable("QT_QPA_PLATFORM") == "offscreen") {
+    if (qEnvironmentVariableIsSet("QT_QPA_PLATFORM") &&
+        qEnvironmentVariable("QT_QPA_PLATFORM") == "offscreen") {
         GTEST_SKIP() << "Skipping visual test in offscreen mode";
     }
 
-    const fluent::FluentElement::Theme previousTheme =
-        fluent::FluentElement::currentTheme();
+    const fluent::FluentElement::Theme previousTheme = fluent::FluentElement::currentTheme();
     fluent::FluentElement::setTheme(fluent::FluentElement::Light);
 
     auto* window = new DataGridVisualWindow;
@@ -1616,39 +1500,30 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
     window->setLayout(layout);
     using Edge = fluent::AnchorLayout::Edge;
 
-    auto* title = new fluent::textfields::Label(
-        QStringLiteral("Project portfolio"), window);
+    auto* title = new fluent::textfields::Label(QStringLiteral("Project portfolio"), window);
     title->setObjectName(QStringLiteral("DataGridVisualCheck.Title"));
     title->setFluentTypography(Typography::FontRole::Title);
 
     auto* subtitle = new fluent::textfields::Label(
-        QStringLiteral("Compare ownership, status, and recent activity across projects."),
-        window);
+        QStringLiteral("Compare ownership, status, and recent activity across projects."), window);
     subtitle->setObjectName(QStringLiteral("DataGridVisualCheck.Subtitle"));
     subtitle->setFluentTypography(Typography::FontRole::Caption);
-    subtitle->setTextColorRole(
-        fluent::textfields::Label::TextColorRole::Secondary);
+    subtitle->setTextColorRole(fluent::textfields::Label::TextColorRole::Secondary);
 
-    auto* themeButton = new fluent::basicinput::Button(
-        QStringLiteral("Theme"), window);
+    auto* themeButton = new fluent::basicinput::Button(QStringLiteral("Theme"), window);
     themeButton->setObjectName(QStringLiteral("DataGridVisualCheck.Theme"));
     themeButton->setFixedSize(84, 32);
 
-    auto* directionButton = new fluent::basicinput::Button(
-        QStringLiteral("Direction"), window);
-    directionButton->setObjectName(
-        QStringLiteral("DataGridVisualCheck.Direction"));
+    auto* directionButton = new fluent::basicinput::Button(QStringLiteral("Direction"), window);
+    directionButton->setObjectName(QStringLiteral("DataGridVisualCheck.Direction"));
     directionButton->setFixedSize(96, 32);
 
-    auto* dataButton = new fluent::basicinput::Button(
-        QStringLiteral("Show empty"), window);
+    auto* dataButton = new fluent::basicinput::Button(QStringLiteral("Show empty"), window);
     dataButton->setObjectName(QStringLiteral("DataGridVisualCheck.Data"));
     dataButton->setFixedSize(104, 32);
 
-    auto* lastRowButton = new fluent::basicinput::Button(
-        QStringLiteral("Last row"), window);
-    lastRowButton->setObjectName(
-        QStringLiteral("DataGridVisualCheck.LastRow"));
+    auto* lastRowButton = new fluent::basicinput::Button(QStringLiteral("Last row"), window);
+    lastRowButton->setObjectName(QStringLiteral("DataGridVisualCheck.LastRow"));
     lastRowButton->setFixedSize(92, 32);
 
     auto* model = new QStandardItemModel(window);
@@ -1657,12 +1532,11 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
     auto* grid = new DataGrid(window);
     grid->setObjectName(QStringLiteral("DataGridVisualCheck.Grid"));
     grid->setModel(model);
-    grid->setPlaceholderText(QStringLiteral(
-        "No records yet. Use Show data to restore the read-only table.\n"
-        "暂无记录，可切回密集数据继续检查。"));
+    grid->setPlaceholderText(
+        QStringLiteral("No records yet. Use Show data to restore the read-only table.\n"
+                       "暂无记录，可切回密集数据继续检查。"));
     grid->setSelectionBehavior(QAbstractItemView::SelectRows);
-    grid->setSelectionMode(
-        fluent::collections::SelectionMode::Single);
+    grid->setSelectionMode(fluent::collections::SelectionMode::Single);
     grid->setScrollChainingEnabled(true);
     grid->horizontalHeader()->resizeSection(0, 176);
     grid->horizontalHeader()->resizeSection(1, 132);
@@ -1712,22 +1586,19 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
     layout->addAnchoredWidget(grid, gridAnchors);
 
     QObject::connect(themeButton, &QPushButton::clicked, window, [] {
-        fluent::FluentElement::setTheme(
-            fluent::FluentElement::currentTheme()
-                    == fluent::FluentElement::Light
-                ? fluent::FluentElement::Dark
-                : fluent::FluentElement::Light);
+        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() ==
+                                                fluent::FluentElement::Light
+                                            ? fluent::FluentElement::Dark
+                                            : fluent::FluentElement::Light);
     });
-    QObject::connect(directionButton, &QPushButton::clicked, window,
-                     [window, directionButton] {
+    QObject::connect(directionButton, &QPushButton::clicked, window, [window, directionButton] {
         const bool rtl = window->layoutDirection() != Qt::RightToLeft;
         window->setLayoutDirection(rtl ? Qt::RightToLeft : Qt::LeftToRight);
         directionButton->setText(rtl ? QStringLiteral("Left to right")
                                      : QStringLiteral("Direction"));
         directionButton->setFixedWidth(rtl ? 112 : 96);
     });
-    QObject::connect(dataButton, &QPushButton::clicked, window,
-                     [model, dataButton, grid] {
+    QObject::connect(dataButton, &QPushButton::clicked, window, [model, dataButton, grid] {
         if (model->rowCount() > 0) {
             model->removeRows(0, model->rowCount());
             dataButton->setText(QStringLiteral("Show data"));
@@ -1738,8 +1609,7 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
             grid->selectRow(2);
         }
     });
-    QObject::connect(lastRowButton, &QPushButton::clicked, window,
-                     [model, grid] {
+    QObject::connect(lastRowButton, &QPushButton::clicked, window, [model, grid] {
         if (model->rowCount() == 0)
             return;
         const int lastRow = model->rowCount() - 1;
@@ -1757,16 +1627,13 @@ TEST_F(DataGridTest, VisualCheck_ReadOnlyCore)
             tests::support::VisualSnapshotOptions options;
             options.windowSize = QSize(1040, 680);
             options.variant = variant;
-            options.focusObjectName =
-                QStringLiteral("DataGridVisualCheck.Grid");
+            options.focusObjectName = QStringLiteral("DataGridVisualCheck.Grid");
             options.theme = theme;
             return options;
         };
         const QList<tests::support::VisualSnapshotOptions> snapshots = {
-            snapshot(QStringLiteral("data-grid-light"),
-                     tests::support::VisualSnapshotTheme::Light),
-            snapshot(QStringLiteral("data-grid-dark"),
-                     tests::support::VisualSnapshotTheme::Dark),
+            snapshot(QStringLiteral("data-grid-light"), tests::support::VisualSnapshotTheme::Light),
+            snapshot(QStringLiteral("data-grid-dark"), tests::support::VisualSnapshotTheme::Dark),
         };
         for (const auto& options : snapshots)
             ASSERT_TRUE(tests::support::captureVisualSnapshot(window, options));

--- a/tests/components/collections/TestDataGrid.cpp
+++ b/tests/components/collections/TestDataGrid.cpp
@@ -530,6 +530,26 @@ TEST_F(DataGridTest, Contract_PublicPropertiesNotifyOnlyOnChanges)
     EXPECT_EQ(chainingSpy.count(), 1);
 }
 
+TEST_F(DataGridTest, Contract_PointerClickPreservesInheritedSignal)
+{
+    QStandardItemModel model(2, 2);
+    DataGrid view;
+    view.setModel(&model);
+    showOffscreen(&view, QSize(420, 220));
+
+    QSignalSpy pressSpy(&view, &QAbstractItemView::pressed);
+    QSignalSpy clickSpy(&view, &QAbstractItemView::clicked);
+    const QModelIndex index = model.index(1, 1);
+    const QPoint point = view.visualRect(index).center();
+    QTest::mouseClick(view.viewport(), Qt::LeftButton, Qt::NoModifier, point);
+    processEvents();
+
+    ASSERT_EQ(pressSpy.count(), 1);
+    EXPECT_EQ(pressSpy.at(0).at(0).value<QModelIndex>(), index);
+    ASSERT_EQ(clickSpy.count(), 1);
+    EXPECT_EQ(clickSpy.at(0).at(0).value<QModelIndex>(), index);
+}
+
 TEST_F(DataGridTest, Contract_LargeModelInitialShowQueriesOnlyViewportBoundedCells)
 {
     constexpr int kRows = 100000;

--- a/tests/components/collections/TestFlowView.cpp
+++ b/tests/components/collections/TestFlowView.cpp
@@ -536,11 +536,19 @@ TEST_F(FlowViewTest, PointerSelectionKeyboardNavigationAndDisabledState)
     flow->setModel(createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(100, 40), QSize(100, 40)}));
 
     showOffscreen(window);
+    QSignalSpy inheritedPressSpy(flow, &QAbstractItemView::pressed);
+    QSignalSpy inheritedClickSpy(flow, &QAbstractItemView::clicked);
     QSignalSpy clickSpy(flow, &FlowView::itemClicked);
     const QRect r1 = flow->visualRect(flow->model()->index(1, 0));
     QTest::mouseClick(flow->viewport(), Qt::LeftButton, Qt::NoModifier, r1.center());
     processEvents();
     EXPECT_EQ(flow->selectedIndex(), 1);
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.takeFirst().at(0)),
+              flow->model()->index(1, 0));
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.takeFirst().at(0)),
+              flow->model()->index(1, 0));
     ASSERT_EQ(clickSpy.count(), 1);
     EXPECT_EQ(clickSpy.takeFirst().at(0).toInt(), 1);
 
@@ -556,6 +564,8 @@ TEST_F(FlowViewTest, PointerSelectionKeyboardNavigationAndDisabledState)
     const QRect r2 = flow->visualRect(flow->model()->index(2, 0));
     QTest::mouseClick(flow->viewport(), Qt::LeftButton, Qt::NoModifier, r2.center());
     processEvents();
+    EXPECT_EQ(inheritedPressSpy.count(), 0);
+    EXPECT_EQ(inheritedClickSpy.count(), 0);
     EXPECT_EQ(clickSpy.count(), 0);
 }
 

--- a/tests/components/collections/TestFlowView.cpp
+++ b/tests/components/collections/TestFlowView.cpp
@@ -42,10 +42,8 @@ enum { DelegateSizeRole = Qt::UserRole + 301 };
 class FlowItemDelegate : public QStyledItemDelegate {
 public:
     explicit FlowItemDelegate(fluent::FluentElement* themeHost, QObject* parent = nullptr)
-        : QStyledItemDelegate(parent)
-        , m_themeHost(themeHost)
-    {
-    }
+        : QStyledItemDelegate(parent), m_themeHost(themeHost)
+    {}
 
     QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
     {
@@ -56,7 +54,8 @@ public:
         return QSize();
     }
 
-    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override
     {
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
@@ -115,10 +114,8 @@ public:
 class LargeFlowModel final : public QAbstractListModel {
 public:
     explicit LargeFlowModel(int rowCount, QObject* parent = nullptr)
-        : QAbstractListModel(parent)
-        , m_rowCount(rowCount)
-    {
-    }
+        : QAbstractListModel(parent), m_rowCount(rowCount)
+    {}
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
@@ -179,7 +176,8 @@ void sendMouseEvent(QWidget* target, QEvent::Type type, const QPoint& position,
     QApplication::sendEvent(target, &event);
 }
 
-QStandardItemModel* createModel(QObject* parent, const QStringList& labels, const QList<QSize>& roleSizes = {},
+QStandardItemModel* createModel(QObject* parent, const QStringList& labels,
+                                const QList<QSize>& roleSizes = {},
                                 const QList<QSize>& delegateSizes = {})
 {
     auto* model = new QStandardItemModel(parent);
@@ -280,7 +278,8 @@ TEST_F(FlowViewTest, RowWrapLayoutVisualRectAndHitTestingUseVariableSizes)
     flow->setHorizontalSpacing(10);
     flow->setVerticalSpacing(10);
     attachDelegate(flow);
-    flow->setModel(createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(120, 80), QSize(160, 50)}));
+    flow->setModel(
+        createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(120, 80), QSize(160, 50)}));
 
     showOffscreen(window);
 
@@ -314,8 +313,7 @@ TEST_F(FlowViewTest, ItemSizeResolutionUsesRoleDelegateAndDefaultWithClamping)
     flow->setMinimumItemSize(QSize(40, 30));
     flow->setMaximumItemSize(QSize(150, 90));
     attachDelegate(flow);
-    flow->setModel(createModel(flow,
-                               {"Role", "Delegate", "Default"},
+    flow->setModel(createModel(flow, {"Role", "Delegate", "Default"},
                                {QSize(300, 5), QSize(), QSize()},
                                {QSize(), QSize(130, 70), QSize()}));
 
@@ -533,7 +531,8 @@ TEST_F(FlowViewTest, PointerSelectionKeyboardNavigationAndDisabledState)
     flow->setHorizontalSpacing(10);
     flow->setVerticalSpacing(10);
     attachDelegate(flow);
-    flow->setModel(createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(100, 40), QSize(100, 40)}));
+    flow->setModel(
+        createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(100, 40), QSize(100, 40)}));
 
     showOffscreen(window);
     QSignalSpy inheritedPressSpy(flow, &QAbstractItemView::pressed);
@@ -615,7 +614,8 @@ TEST_F(FlowViewTest, MultiSelectRequiresControlClickAndDragDoesNotRubberBandSele
     flow->setHorizontalSpacing(10);
     flow->setVerticalSpacing(10);
     attachDelegate(flow);
-    flow->setModel(createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(100, 40), QSize(100, 40)}));
+    flow->setModel(
+        createModel(flow, {"A", "B", "C"}, {QSize(100, 40), QSize(100, 40), QSize(100, 40)}));
 
     showOffscreen(window);
     const QRect r0 = flow->visualRect(flow->model()->index(0, 0));
@@ -627,9 +627,11 @@ TEST_F(FlowViewTest, MultiSelectRequiresControlClickAndDragDoesNotRubberBandSele
     processEvents();
     EXPECT_EQ(flow->selectedRows(), QList<int>({0, 1}));
 
-    QTest::mousePress(flow->viewport(), Qt::LeftButton, Qt::NoModifier, r0.topLeft() + QPoint(2, 2));
+    QTest::mousePress(flow->viewport(), Qt::LeftButton, Qt::NoModifier,
+                      r0.topLeft() + QPoint(2, 2));
     QTest::mouseMove(flow->viewport(), r2.bottomRight() + QPoint(2, 2));
-    QTest::mouseRelease(flow->viewport(), Qt::LeftButton, Qt::NoModifier, r2.bottomRight() + QPoint(2, 2));
+    QTest::mouseRelease(flow->viewport(), Qt::LeftButton, Qt::NoModifier,
+                        r2.bottomRight() + QPoint(2, 2));
     processEvents();
     EXPECT_EQ(flow->selectedRows(), QList<int>({0, 1}));
 }
@@ -659,12 +661,10 @@ TEST_F(FlowViewTest, DragReorderUsesVariableGeometryAndPreservesSelection)
 
     sendMouseEvent(flow->viewport(), QEvent::MouseButtonPress, start, Qt::LeftButton,
                    Qt::LeftButton);
-    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dragStart, Qt::NoButton,
-                   Qt::LeftButton);
-    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dropPoint, Qt::NoButton,
-                   Qt::LeftButton);
+    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dragStart, Qt::NoButton, Qt::LeftButton);
+    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dropPoint, Qt::NoButton, Qt::LeftButton);
     EXPECT_LE(flow->findChildren<QVariantAnimation*>(
-                       QStringLiteral("_q_fluentFlowDragDisplacementAnimation"))
+                      QStringLiteral("_q_fluentFlowDragDisplacementAnimation"))
                   .size(),
               1);
     sendMouseEvent(flow->viewport(), QEvent::MouseButtonRelease, dropPoint, Qt::LeftButton,
@@ -706,19 +706,17 @@ TEST_F(FlowViewTest, DragReorderWithoutModifierSelectsOnlyDraggedItem)
 
     sendMouseEvent(flow->viewport(), QEvent::MouseButtonPress, start, Qt::LeftButton,
                    Qt::LeftButton);
-    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dragStart, Qt::NoButton,
-                   Qt::LeftButton);
-    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dropPoint, Qt::NoButton,
-                   Qt::LeftButton);
+    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dragStart, Qt::NoButton, Qt::LeftButton);
+    sendMouseEvent(flow->viewport(), QEvent::MouseMove, dropPoint, Qt::NoButton, Qt::LeftButton);
     sendMouseEvent(flow->viewport(), QEvent::MouseButtonRelease, dropPoint, Qt::LeftButton,
                    Qt::NoButton);
     processEvents();
 
     const QList<int> selectedRows = flow->selectedRows();
     ASSERT_EQ(selectedRows.size(), 1);
-    EXPECT_EQ(model->index(selectedRows.first(), 0).data(Qt::DisplayRole).toString(), QStringLiteral("C"));
+    EXPECT_EQ(model->index(selectedRows.first(), 0).data(Qt::DisplayRole).toString(),
+              QStringLiteral("C"));
 }
-
 
 TEST_F(FlowViewTest, VisualCheck)
 {
@@ -753,9 +751,11 @@ TEST_F(FlowViewTest, VisualCheck)
     layout->addWidget(flow);
 
     auto* model = createModel(flow,
-                              {"Compact", "Wide card", "Tall", "Chip", "Large", "Small", "Dashboard", "Tag", "Media", "Action"},
-                              {QSize(116, 48), QSize(220, 72), QSize(120, 124), QSize(92, 40), QSize(260, 96),
-                               QSize(84, 44), QSize(180, 110), QSize(100, 40), QSize(210, 120), QSize(138, 54)});
+                              {"Compact", "Wide card", "Tall", "Chip", "Large", "Small",
+                               "Dashboard", "Tag", "Media", "Action"},
+                              {QSize(116, 48), QSize(220, 72), QSize(120, 124), QSize(92, 40),
+                               QSize(260, 96), QSize(84, 44), QSize(180, 110), QSize(100, 40),
+                               QSize(210, 120), QSize(138, 54)});
     flow->setModel(model);
 
     auto* disabled = new FlowView(window);
@@ -765,7 +765,8 @@ TEST_F(FlowViewTest, VisualCheck)
     disabled->setHorizontalSpacing(8);
     disabled->setVerticalSpacing(8);
     attachDelegate(disabled);
-    disabled->setModel(createModel(disabled, {"One", "Two", "Three"}, {QSize(96, 44), QSize(136, 56), QSize(112, 44)}));
+    disabled->setModel(createModel(disabled, {"One", "Two", "Three"},
+                                   {QSize(96, 44), QSize(136, 56), QSize(112, 44)}));
     disabled->anchors()->top = {flow, Edge::Top, 0};
     disabled->anchors()->left = {flow, Edge::Right, 32};
     disabled->anchors()->right = {title, Edge::Right, 0};
@@ -793,7 +794,8 @@ TEST_F(FlowViewTest, VisualCheck)
     layout->addWidget(themeButton);
     QObject::connect(themeButton, &Button::clicked, themeButton, [themeButton]() {
         const bool dark = fluent::FluentElement::currentTheme() == fluent::FluentElement::Dark;
-        fluent::FluentElement::setTheme(dark ? fluent::FluentElement::Light : fluent::FluentElement::Dark);
+        fluent::FluentElement::setTheme(dark ? fluent::FluentElement::Light
+                                             : fluent::FluentElement::Dark);
         themeButton->setText(dark ? QStringLiteral("Dark") : QStringLiteral("Light"));
     });
 

--- a/tests/components/collections/TestGridView.cpp
+++ b/tests/components/collections/TestGridView.cpp
@@ -40,39 +40,47 @@ using namespace fluent;
 namespace {
 
 /** 业务组装：为 GridView 挂上 Fluent 网格项代理。 */
-void attachFluentDelegate(GridView* gv) {
-    gv->setItemDelegate(new gridview_test::FluentGridItemDelegate(
-        static_cast<fluent::FluentElement*>(gv), gv, gv));
+void attachFluentDelegate(GridView* gv)
+{
+    gv->setItemDelegate(
+        new gridview_test::FluentGridItemDelegate(static_cast<fluent::FluentElement*>(gv), gv, gv));
 }
 
 /** 创建 QStringListModel，setModel + attachFluentDelegate。 */
-QStringListModel* attachStringListModel(GridView* gv, const QStringList& rows = {}) {
+QStringListModel* attachStringListModel(GridView* gv, const QStringList& rows = {})
+{
     auto* m = new QStringListModel(rows, gv);
     gv->setModel(m);
     attachFluentDelegate(gv);
     return m;
 }
 
-int itemCount(GridView* gv) {
+int itemCount(GridView* gv)
+{
     const auto* m = gv->model();
     return m ? m->rowCount() : 0;
 }
 
-QString itemText(GridView* gv, int index) {
+QString itemText(GridView* gv, int index)
+{
     const auto* m = gv->model();
-    if (!m || index < 0 || index >= m->rowCount()) return {};
+    if (!m || index < 0 || index >= m->rowCount())
+        return {};
     return m->index(index, 0).data(Qt::DisplayRole).toString();
 }
 
-QStringList modelTexts(const QAbstractItemModel* model) {
+QStringList modelTexts(const QAbstractItemModel* model)
+{
     QStringList texts;
-    if (!model) return texts;
+    if (!model)
+        return texts;
     for (int row = 0; row < model->rowCount(); ++row)
         texts << model->index(row, 0).data(Qt::DisplayRole).toString();
     return texts;
 }
 
-QStandardItemModel* attachStandardModel(GridView* gv, const QStringList& rows) {
+QStandardItemModel* attachStandardModel(GridView* gv, const QStringList& rows)
+{
     auto* model = new QStandardItemModel(gv);
     for (const QString& row : rows)
         model->appendRow(new QStandardItem(row));
@@ -81,19 +89,20 @@ QStandardItemModel* attachStandardModel(GridView* gv, const QStringList& rows) {
     return model;
 }
 
-void showOffscreen(QWidget* window) {
+void showOffscreen(QWidget* window)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     window->show();
     QTest::qWait(50);
 }
 
-QList<QVariantAnimation*> activeDragAnimations(const GridView* gv) {
+QList<QVariantAnimation*> activeDragAnimations(const GridView* gv)
+{
     QList<QVariantAnimation*> animations;
     for (auto* anim : gv->findChildren<QVariantAnimation*>()) {
         if (anim->state() != QAbstractAnimation::Running)
             continue;
-        if (!anim->startValue().canConvert<QPointF>() ||
-            !anim->endValue().canConvert<QPointF>()) {
+        if (!anim->startValue().canConvert<QPointF>() || !anim->endValue().canConvert<QPointF>()) {
             continue;
         }
         animations.append(anim);
@@ -101,7 +110,8 @@ QList<QVariantAnimation*> activeDragAnimations(const GridView* gv) {
     return animations;
 }
 
-void addItem(GridView* gv, const QString& text) {
+void addItem(GridView* gv, const QString& text)
+{
     auto* slm = qobject_cast<QStringListModel*>(gv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -109,7 +119,8 @@ void addItem(GridView* gv, const QString& text) {
     slm->setStringList(list);
 }
 
-void addItems(GridView* gv, const QStringList& texts) {
+void addItems(GridView* gv, const QStringList& texts)
+{
     auto* slm = qobject_cast<QStringListModel*>(gv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -117,7 +128,8 @@ void addItems(GridView* gv, const QStringList& texts) {
     slm->setStringList(list);
 }
 
-void removeItem(GridView* gv, int index) {
+void removeItem(GridView* gv, int index)
+{
     auto* slm = qobject_cast<QStringListModel*>(gv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -127,7 +139,8 @@ void removeItem(GridView* gv, int index) {
     slm->setStringList(list);
 }
 
-void clearItems(GridView* gv) {
+void clearItems(GridView* gv)
+{
     auto* slm = qobject_cast<QStringListModel*>(gv->model());
     ASSERT_NE(slm, nullptr);
     slm->setStringList({});
@@ -136,10 +149,8 @@ void clearItems(GridView* gv) {
 class ResizeSyncFilter : public QObject {
 public:
     ResizeSyncFilter(QObject* parent, std::function<void()> callback)
-        : QObject(parent)
-        , m_callback(std::move(callback))
-    {
-    }
+        : QObject(parent), m_callback(std::move(callback))
+    {}
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override
@@ -162,7 +173,8 @@ private:
 class FluentTestWindow : public QWidget, public fluent::FluentElement {
 public:
     using QWidget::QWidget;
-    void onThemeUpdated() override {
+    void onThemeUpdated() override
+    {
         const auto& c = themeColors();
         setStyleSheet(QString("background-color: %1;").arg(c.bgCanvas.name()));
     }
@@ -170,7 +182,8 @@ public:
 
 class GridViewTest : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         window = new FluentTestWindow();
         window->resize(600, 600);
         window->setMinimumSize(320, 240);
@@ -180,9 +193,7 @@ protected:
         window->onThemeUpdated();
     }
 
-    void TearDown() override {
-        delete window;
-    }
+    void TearDown() override { delete window; }
 
     FluentTestWindow* window;
     AnchorLayout* layout;
@@ -190,7 +201,8 @@ protected:
 
 // ── 数据操作 ──────────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, AddAndRemoveItems) {
+TEST_F(GridViewTest, AddAndRemoveItems)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv);
 
@@ -211,7 +223,8 @@ TEST_F(GridViewTest, AddAndRemoveItems) {
     EXPECT_EQ(itemCount(gv), 0);
 }
 
-TEST_F(GridViewTest, AddItemsBatch) {
+TEST_F(GridViewTest, AddItemsBatch)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv);
     addItems(gv, {"A", "B", "C", "D"});
@@ -219,7 +232,8 @@ TEST_F(GridViewTest, AddItemsBatch) {
     EXPECT_EQ(itemText(gv, 3), "D");
 }
 
-TEST_F(GridViewTest, ItemTextOutOfRange) {
+TEST_F(GridViewTest, ItemTextOutOfRange)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv);
     addItem(gv, "Only");
@@ -229,17 +243,20 @@ TEST_F(GridViewTest, ItemTextOutOfRange) {
 
 // ── 选择模式 ──────────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, DefaultSelectionMode) {
+TEST_F(GridViewTest, DefaultSelectionMode)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->selectionMode(), SelectionMode::Single);
 }
 
-TEST_F(GridViewTest, DefaultEditTriggersDisabled) {
+TEST_F(GridViewTest, DefaultEditTriggersDisabled)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->editTriggers(), QAbstractItemView::NoEditTriggers);
 }
 
-TEST_F(GridViewTest, SelectionModeRegisteredInMetaObject) {
+TEST_F(GridViewTest, SelectionModeRegisteredInMetaObject)
+{
     QMetaEnum me = QMetaEnum::fromType<SelectionMode>();
     ASSERT_TRUE(me.isValid());
     EXPECT_STREQ(me.key(0), "None");
@@ -248,14 +265,16 @@ TEST_F(GridViewTest, SelectionModeRegisteredInMetaObject) {
     EXPECT_STREQ(me.key(3), "Extended");
 }
 
-TEST_F(GridViewTest, SelectionModeNone) {
+TEST_F(GridViewTest, SelectionModeNone)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv, {"A", "B", "C"});
     gv->setSelectionMode(SelectionMode::None);
     EXPECT_EQ(gv->selectionMode(), SelectionMode::None);
 }
 
-TEST_F(GridViewTest, SelectionModeMultiple) {
+TEST_F(GridViewTest, SelectionModeMultiple)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, SIGNAL(selectionModeChanged()));
     gv->setSelectionMode(SelectionMode::Multiple);
@@ -267,7 +286,8 @@ TEST_F(GridViewTest, SelectionModeMultiple) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, SelectionModeExtended) {
+TEST_F(GridViewTest, SelectionModeExtended)
+{
     GridView* gv = new GridView(window);
     gv->setSelectionMode(SelectionMode::Extended);
     EXPECT_EQ(gv->selectionMode(), SelectionMode::Extended);
@@ -275,7 +295,8 @@ TEST_F(GridViewTest, SelectionModeExtended) {
 
 // ── 选中 API ──────────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, SingleSelection) {
+TEST_F(GridViewTest, SingleSelection)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv, {"A", "B", "C"});
 
@@ -288,7 +309,8 @@ TEST_F(GridViewTest, SingleSelection) {
     EXPECT_EQ(gv->selectedIndex(), -1);
 }
 
-TEST_F(GridViewTest, SelectedIndexOutOfRange) {
+TEST_F(GridViewTest, SelectedIndexOutOfRange)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv, {"A", "B"});
     gv->setSelectedIndex(1);
@@ -298,7 +320,8 @@ TEST_F(GridViewTest, SelectedIndexOutOfRange) {
     EXPECT_EQ(gv->selectedIndex(), -1);
 }
 
-TEST_F(GridViewTest, SelectedRowsSortedAscending) {
+TEST_F(GridViewTest, SelectedRowsSortedAscending)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv, {"A", "B", "C", "D"});
     gv->setSelectionMode(SelectionMode::Multiple);
@@ -316,7 +339,8 @@ TEST_F(GridViewTest, SelectedRowsSortedAscending) {
 
 // ── Viewport hover ────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, ViewportHoveredSignal) {
+TEST_F(GridViewTest, ViewportHoveredSignal)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(10, 10, 400, 400);
@@ -337,12 +361,14 @@ TEST_F(GridViewTest, ViewportHoveredSignal) {
 
 // ── Grid 特有属性 ─────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, DefaultCellSize) {
+TEST_F(GridViewTest, DefaultCellSize)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->cellSize(), QSize(112, 112));
 }
 
-TEST_F(GridViewTest, SetCellSize) {
+TEST_F(GridViewTest, SetCellSize)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::cellSizeChanged);
     gv->setCellSize(QSize(150, 150));
@@ -350,21 +376,22 @@ TEST_F(GridViewTest, SetCellSize) {
     EXPECT_EQ(spy.count(), 1);
 
     // gridSize = cellSize + spacing
-    EXPECT_EQ(gv->gridSize(), QSize(150 + gv->horizontalSpacing(),
-                                    150 + gv->verticalSpacing()));
+    EXPECT_EQ(gv->gridSize(), QSize(150 + gv->horizontalSpacing(), 150 + gv->verticalSpacing()));
 
     // 重复设置不触发信号
     gv->setCellSize(QSize(150, 150));
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, DefaultSpacing) {
+TEST_F(GridViewTest, DefaultSpacing)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->horizontalSpacing(), 4);
     EXPECT_EQ(gv->verticalSpacing(), 4);
 }
 
-TEST_F(GridViewTest, SetHorizontalSpacing) {
+TEST_F(GridViewTest, SetHorizontalSpacing)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::horizontalSpacingChanged);
     gv->setHorizontalSpacing(8);
@@ -373,7 +400,8 @@ TEST_F(GridViewTest, SetHorizontalSpacing) {
     EXPECT_EQ(gv->gridSize().width(), gv->cellSize().width() + 8);
 }
 
-TEST_F(GridViewTest, SetVerticalSpacing) {
+TEST_F(GridViewTest, SetVerticalSpacing)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::verticalSpacingChanged);
     gv->setVerticalSpacing(12);
@@ -382,12 +410,14 @@ TEST_F(GridViewTest, SetVerticalSpacing) {
     EXPECT_EQ(gv->gridSize().height(), gv->cellSize().height() + 12);
 }
 
-TEST_F(GridViewTest, DefaultMaxColumns) {
+TEST_F(GridViewTest, DefaultMaxColumns)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->maxColumns(), 0);
 }
 
-TEST_F(GridViewTest, SetMaxColumns) {
+TEST_F(GridViewTest, SetMaxColumns)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::maxColumnsChanged);
     gv->setMaxColumns(3);
@@ -398,7 +428,8 @@ TEST_F(GridViewTest, SetMaxColumns) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
+TEST_F(GridViewTest, ScrollChainingPropertyControlsBoundaryWheel)
+{
     auto* gv = new GridView(window);
     gv->setGeometry(0, 0, 240, 120);
     gv->setCellSize(QSize(100, 80));
@@ -436,7 +467,8 @@ TEST_F(GridViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
     EXPECT_TRUE(containedWheel.isAccepted());
 }
 
-TEST_F(GridViewTest, WheelPassesThroughWhenContentFits) {
+TEST_F(GridViewTest, WheelPassesThroughWhenContentFits)
+{
     auto* gv = new GridView(window);
     gv->setGeometry(0, 0, 300, 220);
     gv->setCellSize(QSize(100, 80));
@@ -457,12 +489,14 @@ TEST_F(GridViewTest, WheelPassesThroughWhenContentFits) {
 
 // ── 容器属性 ──────────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, DefaultFontRole) {
+TEST_F(GridViewTest, DefaultFontRole)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->fontRole(), Typography::FontRole::Body);
 }
 
-TEST_F(GridViewTest, SetFontRole) {
+TEST_F(GridViewTest, SetFontRole)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, SIGNAL(fontRoleChanged()));
     gv->setFontRole(Typography::FontRole::Subtitle);
@@ -470,13 +504,15 @@ TEST_F(GridViewTest, SetFontRole) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, DefaultBorderVisible) {
+TEST_F(GridViewTest, DefaultBorderVisible)
+{
     GridView* gv = new GridView(window);
     EXPECT_TRUE(gv->borderVisible());
     EXPECT_TRUE(gv->isBorderVisible());
 }
 
-TEST_F(GridViewTest, SetBorderVisible) {
+TEST_F(GridViewTest, SetBorderVisible)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::borderVisibleChanged);
     gv->setBorderVisible(false);
@@ -488,7 +524,8 @@ TEST_F(GridViewTest, SetBorderVisible) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, BackgroundVisibleProperty) {
+TEST_F(GridViewTest, BackgroundVisibleProperty)
+{
     GridView* gv = new GridView(window);
     EXPECT_TRUE(gv->backgroundVisible());
     EXPECT_TRUE(gv->isBackgroundVisible());
@@ -501,12 +538,14 @@ TEST_F(GridViewTest, BackgroundVisibleProperty) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, DefaultHeaderText) {
+TEST_F(GridViewTest, DefaultHeaderText)
+{
     GridView* gv = new GridView(window);
     EXPECT_TRUE(gv->headerText().isEmpty());
 }
 
-TEST_F(GridViewTest, SetHeaderText) {
+TEST_F(GridViewTest, SetHeaderText)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::headerTextChanged);
     gv->setHeaderText("My Grid");
@@ -517,12 +556,14 @@ TEST_F(GridViewTest, SetHeaderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, DefaultPlaceholderText) {
+TEST_F(GridViewTest, DefaultPlaceholderText)
+{
     GridView* gv = new GridView(window);
     EXPECT_TRUE(gv->placeholderText().isEmpty());
 }
 
-TEST_F(GridViewTest, SetPlaceholderText) {
+TEST_F(GridViewTest, SetPlaceholderText)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::placeholderTextChanged);
     gv->setPlaceholderText("No items");
@@ -533,7 +574,8 @@ TEST_F(GridViewTest, SetPlaceholderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, HeaderVisibleWhenTextSet) {
+TEST_F(GridViewTest, HeaderVisibleWhenTextSet)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(10, 10, 400, 400);
@@ -546,7 +588,8 @@ TEST_F(GridViewTest, HeaderVisibleWhenTextSet) {
     EXPECT_EQ(headerLabel->text(), "Grid Header");
 }
 
-TEST_F(GridViewTest, HeaderHiddenWhenTextEmpty) {
+TEST_F(GridViewTest, HeaderHiddenWhenTextEmpty)
+{
     GridView* gv = new GridView(window);
     gv->setHeaderText("Header");
     gv->setHeaderText("");
@@ -555,7 +598,8 @@ TEST_F(GridViewTest, HeaderHiddenWhenTextEmpty) {
     EXPECT_FALSE(headerLabel->isVisible());
 }
 
-TEST_F(GridViewTest, ItemClickedSignal) {
+TEST_F(GridViewTest, ItemClickedSignal)
+{
     GridView* gv = new GridView(window);
     attachStringListModel(gv, {"A", "B", "C"});
     QSignalSpy spy(gv, SIGNAL(itemClicked(int)));
@@ -566,7 +610,8 @@ TEST_F(GridViewTest, ItemClickedSignal) {
     EXPECT_EQ(spy.at(0).at(0).toInt(), 0);
 }
 
-TEST_F(GridViewTest, ReorderEnabledPointerClicksPreserveInheritedSignal) {
+TEST_F(GridViewTest, ReorderEnabledPointerClicksPreserveInheritedSignal)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* gv = new GridView(window);
     gv->setGeometry(0, 0, 600, 400);
@@ -608,7 +653,8 @@ TEST_F(GridViewTest, ReorderEnabledPointerClicksPreserveInheritedSignal) {
     EXPECT_EQ(itemClickSpy.at(0).at(0).toInt(), index.row());
 }
 
-TEST_F(GridViewTest, ReorderEnabledProgrammaticSelectionPreservesInheritedClick) {
+TEST_F(GridViewTest, ReorderEnabledProgrammaticSelectionPreservesInheritedClick)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* gv = new GridView(window);
     gv->setGeometry(0, 0, 600, 400);
@@ -638,17 +684,20 @@ TEST_F(GridViewTest, ReorderEnabledProgrammaticSelectionPreservesInheritedClick)
     EXPECT_EQ(itemClickSpy.at(0).at(0).toInt(), index.row());
 }
 
-TEST_F(GridViewTest, FluentScrollBarExists) {
+TEST_F(GridViewTest, FluentScrollBarExists)
+{
     GridView* gv = new GridView(window);
     EXPECT_NE(gv->verticalFluentScrollBar(), nullptr);
 }
 
-TEST_F(GridViewTest, ViewDoesNotProvideModelByDefault) {
+TEST_F(GridViewTest, ViewDoesNotProvideModelByDefault)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->model(), nullptr);
 }
 
-TEST_F(GridViewTest, SelectionQueriesAreSafeWithoutModel) {
+TEST_F(GridViewTest, SelectionQueriesAreSafeWithoutModel)
+{
     GridView* gv = new GridView(window);
 
     EXPECT_EQ(gv->selectedIndex(), -1);
@@ -657,7 +706,8 @@ TEST_F(GridViewTest, SelectionQueriesAreSafeWithoutModel) {
     EXPECT_EQ(gv->selectedIndex(), -1);
 }
 
-TEST_F(GridViewTest, SelectionQueriesAreSafeAfterExternalModelDestruction) {
+TEST_F(GridViewTest, SelectionQueriesAreSafeAfterExternalModelDestruction)
+{
     GridView* gv = new GridView(window);
     auto* model = new QStringListModel({"External"});
     gv->setModel(model);
@@ -671,7 +721,8 @@ TEST_F(GridViewTest, SelectionQueriesAreSafeAfterExternalModelDestruction) {
     EXPECT_EQ(gv->selectedIndex(), -1);
 }
 
-TEST_F(GridViewTest, IconModeAndWrapping) {
+TEST_F(GridViewTest, IconModeAndWrapping)
+{
     GridView* gv = new GridView(window);
     EXPECT_EQ(gv->viewMode(), QListView::IconMode);
     EXPECT_TRUE(gv->isWrapping());
@@ -681,12 +732,13 @@ TEST_F(GridViewTest, IconModeAndWrapping) {
 
 // ── 列布局测试 ────────────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, ColumnsAutoFit) {
+TEST_F(GridViewTest, ColumnsAutoFit)
+{
     // 容器宽度 600，cellSize 112 + hSpacing 4 = 116 per col → 600/116 = 5 列
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(0, 0, 600, 400);
-    attachStringListModel(gv, {"A","B","C","D","E","F","G","H","I","J"});
+    attachStringListModel(gv, {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"});
     window->show();
     QTest::qWait(50);
 
@@ -701,12 +753,13 @@ TEST_F(GridViewTest, ColumnsAutoFit) {
     EXPECT_GT(r5.top(), r4.top());
 }
 
-TEST_F(GridViewTest, ColumnsChangeOnResize) {
+TEST_F(GridViewTest, ColumnsChangeOnResize)
+{
     // 调整容器宽度后列数应改变
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(0, 0, 600, 400);
-    attachStringListModel(gv, {"A","B","C","D","E","F","G","H"});
+    attachStringListModel(gv, {"A", "B", "C", "D", "E", "F", "G", "H"});
     window->show();
     QTest::qWait(50);
 
@@ -723,14 +776,15 @@ TEST_F(GridViewTest, ColumnsChangeOnResize) {
     EXPECT_GT(r3_narrow.top(), r0_narrow.top());
 }
 
-TEST_F(GridViewTest, CellSizeAffectsColumns) {
+TEST_F(GridViewTest, CellSizeAffectsColumns)
+{
     // 大 cellSize 导致更少列数
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(0, 0, 500, 400);
     gv->setCellSize(QSize(200, 150));
     gv->setHorizontalSpacing(8);
-    attachStringListModel(gv, {"A","B","C","D","E","F"});
+    attachStringListModel(gv, {"A", "B", "C", "D", "E", "F"});
     window->show();
     QTest::qWait(50);
 
@@ -750,7 +804,8 @@ namespace {
 constexpr int kMinimumShimmerVisibleMs = 1200;
 
 /** 异步加载网络图片到 QStandardItem 的 ImageRole */
-void loadNetworkImage(QStandardItem* item, const QUrl& url) {
+void loadNetworkImage(QStandardItem* item, const QUrl& url)
+{
     item->setData(true, gridview_test::ImageLoadingRole);
     QTimer::singleShot(kMinimumShimmerVisibleMs, qApp, [item, url]() {
         auto* nam = new QNetworkAccessManager(qApp);
@@ -773,12 +828,14 @@ void loadNetworkImage(QStandardItem* item, const QUrl& url) {
 
 // ── Drag reorder tests ────────────────────────────────────────────────────────
 
-TEST_F(GridViewTest, DefaultCanReorderItems) {
+TEST_F(GridViewTest, DefaultCanReorderItems)
+{
     GridView* gv = new GridView(window);
     EXPECT_FALSE(gv->canReorderItems());
 }
 
-TEST_F(GridViewTest, SetCanReorderItems) {
+TEST_F(GridViewTest, SetCanReorderItems)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::canReorderItemsChanged);
     gv->setCanReorderItems(true);
@@ -786,14 +843,16 @@ TEST_F(GridViewTest, SetCanReorderItems) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, DisableCanReorderItems) {
+TEST_F(GridViewTest, DisableCanReorderItems)
+{
     GridView* gv = new GridView(window);
     gv->setCanReorderItems(true);
     gv->setCanReorderItems(false);
     EXPECT_FALSE(gv->canReorderItems());
 }
 
-TEST_F(GridViewTest, CanReorderItemsSignalNotDuplicate) {
+TEST_F(GridViewTest, CanReorderItemsSignalNotDuplicate)
+{
     GridView* gv = new GridView(window);
     QSignalSpy spy(gv, &GridView::canReorderItemsChanged);
     gv->setCanReorderItems(true);
@@ -801,7 +860,8 @@ TEST_F(GridViewTest, CanReorderItemsSignalNotDuplicate) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(GridViewTest, ReorderMoveRowInModel) {
+TEST_F(GridViewTest, ReorderMoveRowInModel)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
     gv->setGeometry(10, 10, 400, 300);
@@ -821,28 +881,31 @@ TEST_F(GridViewTest, ReorderMoveRowInModel) {
 
 // ── Selection mode enum mapping to Qt ─────────────────────────────────────────
 
-TEST_F(GridViewTest, SelectionModeNoneMapsToNoSelection) {
+TEST_F(GridViewTest, SelectionModeNoneMapsToNoSelection)
+{
     GridView* gv = new GridView(window);
     gv->setSelectionMode(SelectionMode::None);
-    EXPECT_EQ(static_cast<QAbstractItemView*>(gv)->selectionMode(),
-              QAbstractItemView::NoSelection);
+    EXPECT_EQ(static_cast<QAbstractItemView*>(gv)->selectionMode(), QAbstractItemView::NoSelection);
 }
 
-TEST_F(GridViewTest, SelectionModeSingleMapsToSingleSelection) {
+TEST_F(GridViewTest, SelectionModeSingleMapsToSingleSelection)
+{
     GridView* gv = new GridView(window);
     gv->setSelectionMode(SelectionMode::Single);
     EXPECT_EQ(static_cast<QAbstractItemView*>(gv)->selectionMode(),
               QAbstractItemView::SingleSelection);
 }
 
-TEST_F(GridViewTest, SelectionModeMultipleMapsToMultiSelection) {
+TEST_F(GridViewTest, SelectionModeMultipleMapsToMultiSelection)
+{
     GridView* gv = new GridView(window);
     gv->setSelectionMode(SelectionMode::Multiple);
     EXPECT_EQ(static_cast<QAbstractItemView*>(gv)->selectionMode(),
               QAbstractItemView::MultiSelection);
 }
 
-TEST_F(GridViewTest, SelectionModeExtendedMapsToExtendedSelection) {
+TEST_F(GridViewTest, SelectionModeExtendedMapsToExtendedSelection)
+{
     GridView* gv = new GridView(window);
     gv->setSelectionMode(SelectionMode::Extended);
     EXPECT_EQ(static_cast<QAbstractItemView*>(gv)->selectionMode(),
@@ -851,7 +914,8 @@ TEST_F(GridViewTest, SelectionModeExtendedMapsToExtendedSelection) {
 
 // ── Multiple selection behavior ───────────────────────────────────────────────
 
-TEST_F(GridViewTest, MultipleSelectionClickToggle) {
+TEST_F(GridViewTest, MultipleSelectionClickToggle)
+{
     // In Multiple mode, clicking an item toggles it without affecting others
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -885,7 +949,8 @@ TEST_F(GridViewTest, MultipleSelectionClickToggle) {
     EXPECT_EQ(sel.at(0), 2);
 }
 
-TEST_F(GridViewTest, ExtendedSelectionShiftClick) {
+TEST_F(GridViewTest, ExtendedSelectionShiftClick)
+{
     // In Extended mode, Shift+click selects a range
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -912,7 +977,8 @@ TEST_F(GridViewTest, ExtendedSelectionShiftClick) {
     EXPECT_TRUE(sel.contains(3));
 }
 
-TEST_F(GridViewTest, ExtendedSelectionCtrlClick) {
+TEST_F(GridViewTest, ExtendedSelectionCtrlClick)
+{
     // In Extended mode, Ctrl+click adds individual items
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -937,7 +1003,8 @@ TEST_F(GridViewTest, ExtendedSelectionCtrlClick) {
     EXPECT_TRUE(sel.contains(3));
 }
 
-TEST_F(GridViewTest, ExtendedSelectionPlainClickClearsOthers) {
+TEST_F(GridViewTest, ExtendedSelectionPlainClickClearsOthers)
+{
     // In Extended mode, a plain click clears previous selection
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -968,7 +1035,8 @@ TEST_F(GridViewTest, ExtendedSelectionPlainClickClearsOthers) {
 
 // ── Drag reorder + selection mode interaction ─────────────────────────────────
 
-TEST_F(GridViewTest, DragReorderSingleMode) {
+TEST_F(GridViewTest, DragReorderSingleMode)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1015,10 +1083,11 @@ TEST_F(GridViewTest, DragReorderSingleMode) {
     QStringList result;
     for (int i = 0; i < mdl->rowCount(); ++i)
         result << mdl->index(i, 0).data().toString();
-    EXPECT_NE(result.at(0), "A");  // A should have moved from index 0
+    EXPECT_NE(result.at(0), "A"); // A should have moved from index 0
 }
 
-TEST_F(GridViewTest, DragReorderBoundaryJitterKeepsStableTargetUntilRelease) {
+TEST_F(GridViewTest, DragReorderBoundaryJitterKeepsStableTargetUntilRelease)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1038,7 +1107,8 @@ TEST_F(GridViewTest, DragReorderBoundaryJitterKeepsStableTargetUntilRelease) {
 
     QTest::mousePress(gv->viewport(), Qt::LeftButton, Qt::NoModifier, sourceRect.center());
     QTest::qWait(10);
-    QTest::mouseMove(gv->viewport(), sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
+    QTest::mouseMove(gv->viewport(),
+                     sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
     QTest::qWait(10);
 
     const QPoint stablePoint = boundaryCenter - QPoint(10, 0);
@@ -1046,13 +1116,9 @@ TEST_F(GridViewTest, DragReorderBoundaryJitterKeepsStableTargetUntilRelease) {
     QTest::qWait(10);
 
     const QStringList beforeRelease = modelTexts(mdl);
-    const QList<QPoint> jitterPoints{
-        boundaryCenter + QPoint(3, 0),
-        boundaryCenter - QPoint(2, 0),
-        boundaryCenter + QPoint(2, 0),
-        boundaryCenter - QPoint(3, 0),
-        boundaryCenter + QPoint(3, 0)
-    };
+    const QList<QPoint> jitterPoints{boundaryCenter + QPoint(3, 0), boundaryCenter - QPoint(2, 0),
+                                     boundaryCenter + QPoint(2, 0), boundaryCenter - QPoint(3, 0),
+                                     boundaryCenter + QPoint(3, 0)};
 
     for (const QPoint& point : jitterPoints) {
         QTest::mouseMove(gv->viewport(), point);
@@ -1067,7 +1133,8 @@ TEST_F(GridViewTest, DragReorderBoundaryJitterKeepsStableTargetUntilRelease) {
     EXPECT_EQ(modelTexts(mdl), (QStringList{"B", "A", "C", "D", "E"}));
 }
 
-TEST_F(GridViewTest, DragReorderClearThresholdCrossingChangesTarget) {
+TEST_F(GridViewTest, DragReorderClearThresholdCrossingChangesTarget)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1087,7 +1154,8 @@ TEST_F(GridViewTest, DragReorderClearThresholdCrossingChangesTarget) {
 
     QTest::mousePress(gv->viewport(), Qt::LeftButton, Qt::NoModifier, sourceRect.center());
     QTest::qWait(10);
-    QTest::mouseMove(gv->viewport(), sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
+    QTest::mouseMove(gv->viewport(),
+                     sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
     QTest::qWait(10);
 
     QTest::mouseMove(gv->viewport(), boundaryCenter - QPoint(10, 0));
@@ -1108,7 +1176,8 @@ TEST_F(GridViewTest, DragReorderClearThresholdCrossingChangesTarget) {
     EXPECT_EQ(modelTexts(mdl), (QStringList{"B", "C", "A", "D", "E"}));
 }
 
-TEST_F(GridViewTest, DragDisplacementRepeatedStableMoveKeepsRunningAnimations) {
+TEST_F(GridViewTest, DragDisplacementRepeatedStableMoveKeepsRunningAnimations)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1125,7 +1194,8 @@ TEST_F(GridViewTest, DragDisplacementRepeatedStableMoveKeepsRunningAnimations) {
     const QPoint stablePoint = targetRect.center() - QPoint(10, 0);
 
     QTest::mousePress(gv->viewport(), Qt::LeftButton, Qt::NoModifier, sourceRect.center());
-    QTest::mouseMove(gv->viewport(), sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
+    QTest::mouseMove(gv->viewport(),
+                     sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
     QTest::mouseMove(gv->viewport(), stablePoint);
 
     const QList<QVariantAnimation*> firstAnimations = activeDragAnimations(gv);
@@ -1141,7 +1211,8 @@ TEST_F(GridViewTest, DragDisplacementRepeatedStableMoveKeepsRunningAnimations) {
     QTest::qWait(50);
 }
 
-TEST_F(GridViewTest, DragReorderMultipleMode) {
+TEST_F(GridViewTest, DragReorderMultipleMode)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1192,7 +1263,8 @@ TEST_F(GridViewTest, DragReorderMultipleMode) {
     EXPECT_NE(result.at(0), "A");
 }
 
-TEST_F(GridViewTest, DragReorderSelectedItemsMoveAsGroupInMultipleMode) {
+TEST_F(GridViewTest, DragReorderSelectedItemsMoveAsGroupInMultipleMode)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1217,7 +1289,8 @@ TEST_F(GridViewTest, DragReorderSelectedItemsMoveAsGroupInMultipleMode) {
 
     QTest::mousePress(gv->viewport(), Qt::LeftButton, Qt::NoModifier, sourceRect.center());
     QTest::qWait(10);
-    QTest::mouseMove(gv->viewport(), sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
+    QTest::mouseMove(gv->viewport(),
+                     sourceRect.center() + QPoint(QApplication::startDragDistance() + 2, 0));
     QTest::qWait(10);
 
     const QStringList beforeRelease = modelTexts(mdl);
@@ -1236,7 +1309,8 @@ TEST_F(GridViewTest, DragReorderSelectedItemsMoveAsGroupInMultipleMode) {
     EXPECT_TRUE(selectedRows.contains(4));
 }
 
-TEST_F(GridViewTest, DragReorderExtendedMode) {
+TEST_F(GridViewTest, DragReorderExtendedMode)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1288,7 +1362,8 @@ TEST_F(GridViewTest, DragReorderExtendedMode) {
     EXPECT_NE(result.at(1), "B");
 }
 
-TEST_F(GridViewTest, DragReorderNoneSelectionDisablesDrag) {
+TEST_F(GridViewTest, DragReorderNoneSelectionDisablesDrag)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1327,7 +1402,8 @@ TEST_F(GridViewTest, DragReorderNoneSelectionDisablesDrag) {
     EXPECT_EQ(reorderSpy.count(), 1);
 }
 
-TEST_F(GridViewTest, DragReorderDisabledWhenFlagOff) {
+TEST_F(GridViewTest, DragReorderDisabledWhenFlagOff)
+{
     // canReorderItems = false: no reorder should happen
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -1362,7 +1438,8 @@ TEST_F(GridViewTest, DragReorderDisabledWhenFlagOff) {
     EXPECT_EQ(modelTexts(mdl), beforeDrag);
 }
 
-TEST_F(GridViewTest, DragReorderPreservesSelectionInMultipleMode) {
+TEST_F(GridViewTest, DragReorderPreservesSelectionInMultipleMode)
+{
     // After drag reorder in Multiple mode, selections should adapt (moved item selected)
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -1400,7 +1477,8 @@ TEST_F(GridViewTest, DragReorderPreservesSelectionInMultipleMode) {
     }
 }
 
-TEST_F(GridViewTest, ReorderStandardItemModelTakeRowFallback) {
+TEST_F(GridViewTest, ReorderStandardItemModelTakeRowFallback)
+{
     if (tests::support::isHeadlessPlatform()) {
         GTEST_SKIP() << "Requires a real windowing platform; offscreen cannot deliver "
                         "synthetic pointer/keyboard input or show native popups.";
@@ -1443,7 +1521,8 @@ TEST_F(GridViewTest, ReorderStandardItemModelTakeRowFallback) {
     EXPECT_EQ(mdl->index(0, 0).data().toString(), "Z");
 }
 
-TEST_F(GridViewTest, DragReorderItemReorderedSignalArgs) {
+TEST_F(GridViewTest, DragReorderItemReorderedSignalArgs)
+{
     // Verify itemReordered signal carries correct from/to arguments
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     GridView* gv = new GridView(window);
@@ -1475,15 +1554,15 @@ TEST_F(GridViewTest, DragReorderItemReorderedSignalArgs) {
 
     if (reorderSpy.count() == 1) {
         int fromIdx = reorderSpy.at(0).at(0).toInt();
-        int toIdx   = reorderSpy.at(0).at(1).toInt();
+        int toIdx = reorderSpy.at(0).at(1).toInt();
         EXPECT_EQ(fromIdx, 0);
-        EXPECT_GE(toIdx, 1);     // moved forward
+        EXPECT_GE(toIdx, 1); // moved forward
         EXPECT_LT(toIdx, 4);
     }
 }
 
-
-TEST_F(GridViewTest, VisualCheck) {
+TEST_F(GridViewTest, VisualCheck)
+{
     if (qEnvironmentVariableIsSet("SKIP_VISUAL_TEST")) {
         GTEST_SKIP() << "Set SKIP_VISUAL_TEST=1 to skip visual tests";
     }
@@ -1508,15 +1587,16 @@ TEST_F(GridViewTest, VisualCheck) {
     auto* fluentVBar = new fluent::scrolling::ScrollBar(Qt::Vertical, scrollArea);
     fluentVBar->setObjectName("fluentScrollAreaVBar");
     auto* nativeVBar = scrollArea->verticalScrollBar();
-    QObject::connect(nativeVBar,  &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
-    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar,  &QScrollBar::setValue);
+    QObject::connect(nativeVBar, &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
+    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar, &QScrollBar::setValue);
 
     auto syncFluentBar = [scrollArea, fluentVBar, nativeVBar]() {
         fluentVBar->setRange(nativeVBar->minimum(), nativeVBar->maximum());
         fluentVBar->setPageStep(nativeVBar->pageStep());
         const bool need = nativeVBar->maximum() > nativeVBar->minimum();
         fluentVBar->setVisible(need);
-        if (!need) return;
+        if (!need)
+            return;
         const QRect r = scrollArea->rect();
         const int x = r.right() - fluentVBar->thickness() + 1;
         fluentVBar->setGeometry(x, r.top() + 2, fluentVBar->thickness(), r.height() - 4);
@@ -1564,37 +1644,37 @@ TEST_F(GridViewTest, VisualCheck) {
     gv1->setVerticalSpacing(6);
 
     auto* model1 = new QStandardItemModel(gv1);
-    struct ItemInfo { QString name; QString likes; QString seed; };
+    struct ItemInfo {
+        QString name;
+        QString likes;
+        QString seed;
+    };
     QList<ItemInfo> items1 = {
-        {"Item 1", "90 Likes", "red-forest"},
-        {"Item 2", "84 Likes", "carousel"},
-        {"Item 3", "96 Likes", "waterfall"},
-        {"Item 4", "79 Likes", "green-valley"},
-        {"Item 5", "32 Likes", "lake-pier"},
-        {"Item 6", "34 Likes", "blue-sky"},
-        {"Item 7", "48 Likes", "stone-arch"},
-        {"Item 8", "90 Likes", "mountain-snow"},
+        {"Item 1", "90 Likes", "red-forest"}, {"Item 2", "84 Likes", "carousel"},
+        {"Item 3", "96 Likes", "waterfall"},  {"Item 4", "79 Likes", "green-valley"},
+        {"Item 5", "32 Likes", "lake-pier"},  {"Item 6", "34 Likes", "blue-sky"},
+        {"Item 7", "48 Likes", "stone-arch"}, {"Item 8", "90 Likes", "mountain-snow"},
     };
     for (const auto& info : items1) {
         auto* item = new QStandardItem(info.name);
         item->setData(info.likes, Qt::ToolTipRole);
         loadNetworkImage(item,
-            QUrl(QString("https://picsum.photos/seed/%1/280/200").arg(info.seed)));
+                         QUrl(QString("https://picsum.photos/seed/%1/280/200").arg(info.seed)));
         model1->appendRow(item);
     }
     gv1->setModel(model1);
     attachFluentDelegate(gv1);
     gv1->setSelectedIndex(5);
     gv1->setFixedHeight(280);
-    gv1->anchors()->top   = {gvLoading, Edge::Bottom,  16};
-    gv1->anchors()->left  = {content, Edge::Left, 20};
+    gv1->anchors()->top = {gvLoading, Edge::Bottom, 16};
+    gv1->anchors()->left = {content, Edge::Left, 20};
     gv1->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(gv1);
 
     // ── GridView 2: 多选 + 图片 + check 浮层 (对应 WinUI Content inside of a GridView) ──
     Label* header2 = new Label("Content inside of a GridView.", content);
     header2->setFluentTypography(Typography::FontRole::BodyStrong);
-    header2->anchors()->top  = {gv1, Edge::Bottom, 16};
+    header2->anchors()->top = {gv1, Edge::Bottom, 16};
     header2->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header2);
 
@@ -1606,13 +1686,12 @@ TEST_F(GridViewTest, VisualCheck) {
     gv2->setBorderVisible(false);
 
     auto* model2 = new QStandardItemModel(gv2);
-    QStringList seeds2 = {"autumn-leaves", "merry-go-round", "bicycle-field",
-                          "green-meadow", "harbor-boats", "beach-run",
-                          "castle-gate", "mountain-range"};
+    QStringList seeds2 = {"autumn-leaves", "merry-go-round", "bicycle-field", "green-meadow",
+                          "harbor-boats",  "beach-run",      "castle-gate",   "mountain-range"};
     for (int i = 0; i < seeds2.size(); ++i) {
         auto* item = new QStandardItem(QString("Photo %1").arg(i + 1));
         loadNetworkImage(item,
-            QUrl(QString("https://picsum.photos/seed/%1/320/240").arg(seeds2[i])));
+                         QUrl(QString("https://picsum.photos/seed/%1/320/240").arg(seeds2[i])));
         model2->appendRow(item);
     }
     gv2->setModel(model2);
@@ -1625,8 +1704,8 @@ TEST_F(GridViewTest, VisualCheck) {
     gv2->selectionModel()->select(model2->index(6, 0), QItemSelectionModel::Select);
     gv2->selectionModel()->select(model2->index(7, 0), QItemSelectionModel::Select);
     gv2->setFixedHeight(300);
-    gv2->anchors()->top   = {header2, Edge::Bottom, 8};
-    gv2->anchors()->left  = {content, Edge::Left, 20};
+    gv2->anchors()->top = {header2, Edge::Bottom, 8};
+    gv2->anchors()->left = {content, Edge::Left, 20};
     gv2->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(gv2);
 
@@ -1637,15 +1716,15 @@ TEST_F(GridViewTest, VisualCheck) {
     gv3->setBorderVisible(true);
     attachStringListModel(gv3);
     gv3->setFixedHeight(80);
-    gv3->anchors()->top   = {gv2, Edge::Bottom, 16};
-    gv3->anchors()->left  = {content, Edge::Left, 20};
+    gv3->anchors()->top = {gv2, Edge::Bottom, 16};
+    gv3->anchors()->left = {content, Edge::Left, 20};
     gv3->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(gv3);
 
     // ── GridView 4: 拖拽重排 (对应 WinUI CanReorderItems) ──
     Label* header4 = new Label("Drag to reorder items.", content);
     header4->setFluentTypography(Typography::FontRole::BodyStrong);
-    header4->anchors()->top  = {gv3, Edge::Bottom, 16};
+    header4->anchors()->top = {gv3, Edge::Bottom, 16};
     header4->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header4);
 
@@ -1657,27 +1736,26 @@ TEST_F(GridViewTest, VisualCheck) {
     gv4->setBorderVisible(true);
 
     auto* model4 = new QStandardItemModel(gv4);
-    QStringList seeds4 = {"sunset-bay", "forest-path", "city-lights",
-                          "ocean-wave", "desert-dune", "snowy-peak",
-                          "river-bend", "flower-field", "night-sky"};
+    QStringList seeds4 = {"sunset-bay", "forest-path", "city-lights",  "ocean-wave", "desert-dune",
+                          "snowy-peak", "river-bend",  "flower-field", "night-sky"};
     for (int i = 0; i < seeds4.size(); ++i) {
         auto* item = new QStandardItem(QString("Tile %1").arg(i + 1));
         loadNetworkImage(item,
-            QUrl(QString("https://picsum.photos/seed/%1/240/180").arg(seeds4[i])));
+                         QUrl(QString("https://picsum.photos/seed/%1/240/180").arg(seeds4[i])));
         model4->appendRow(item);
     }
     gv4->setModel(model4);
     attachFluentDelegate(gv4);
     gv4->setFixedHeight(230);
-    gv4->anchors()->top   = {header4, Edge::Bottom, 8};
-    gv4->anchors()->left  = {content, Edge::Left, 20};
+    gv4->anchors()->top = {header4, Edge::Bottom, 8};
+    gv4->anchors()->left = {content, Edge::Left, 20};
     gv4->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(gv4);
 
     // ── Section 5: Selection Mode Comparison (None / Single / Multiple / Extended) ──
     Label* header5 = new Label("Selection Mode Comparison", content);
     header5->setFluentTypography(Typography::FontRole::BodyStrong);
-    header5->anchors()->top  = {gv4, Edge::Bottom, 24};
+    header5->anchors()->top = {gv4, Edge::Bottom, 24};
     header5->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header5);
 
@@ -1716,8 +1794,8 @@ TEST_F(GridViewTest, VisualCheck) {
     modeRow1->setFixedHeight(170);
     {
         AnchorLayout::Anchors a;
-        a.top   = {header5, Edge::Bottom, 8};
-        a.left  = {content, Edge::Left,  20};
+        a.top = {header5, Edge::Bottom, 8};
+        a.left = {content, Edge::Left, 20};
         a.right = {content, Edge::Right, -20};
         innerLayout->addAnchoredWidget(modeRow1, a);
     }
@@ -1731,9 +1809,12 @@ TEST_F(GridViewTest, VisualCheck) {
     auto* gvMultiDemo = createModeGrid(modeRow2);
     gvMultiDemo->setHeaderText("Multiple (click toggles)");
     gvMultiDemo->setSelectionMode(SelectionMode::Multiple);
-    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(0, 0), QItemSelectionModel::Select);
-    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(2, 0), QItemSelectionModel::Select);
-    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(5, 0), QItemSelectionModel::Select);
+    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(0, 0),
+                                          QItemSelectionModel::Select);
+    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(2, 0),
+                                          QItemSelectionModel::Select);
+    gvMultiDemo->selectionModel()->select(gvMultiDemo->model()->index(5, 0),
+                                          QItemSelectionModel::Select);
 
     auto* gvExtDemo = createModeGrid(modeRow2);
     gvExtDemo->setHeaderText("Extended (Ctrl/Shift+click)");
@@ -1747,16 +1828,16 @@ TEST_F(GridViewTest, VisualCheck) {
     modeRow2->setFixedHeight(170);
     {
         AnchorLayout::Anchors a;
-        a.top   = {modeRow1, Edge::Bottom, 8};
-        a.left  = {content,  Edge::Left,  20};
-        a.right = {content,  Edge::Right, -20};
+        a.top = {modeRow1, Edge::Bottom, 8};
+        a.left = {content, Edge::Left, 20};
+        a.right = {content, Edge::Right, -20};
         innerLayout->addAnchoredWidget(modeRow2, a);
     }
 
     // ── Section 6: Drag Reorder × Selection Mode ──
     Label* header6 = new Label("Drag Reorder \u00d7 Selection Mode", content);
     header6->setFluentTypography(Typography::FontRole::BodyStrong);
-    header6->anchors()->top  = {modeRow2, Edge::Bottom, 24};
+    header6->anchors()->top = {modeRow2, Edge::Bottom, 24};
     header6->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header6);
 
@@ -1776,13 +1857,12 @@ TEST_F(GridViewTest, VisualCheck) {
     gvMultiDrag->setVerticalSpacing(4);
     {
         auto* mdl = new QStandardItemModel(gvMultiDrag);
-        QStringList seeds = {"alpine-lake", "bamboo-grove", "coral-reef",
-                             "desert-bloom", "emerald-isle", "frozen-fjord",
-                             "golden-gate", "highland-mist"};
+        QStringList seeds = {"alpine-lake",  "bamboo-grove", "coral-reef",  "desert-bloom",
+                             "emerald-isle", "frozen-fjord", "golden-gate", "highland-mist"};
         for (int i = 0; i < seeds.size(); ++i) {
             auto* item = new QStandardItem(QString("Tile %1").arg(i + 1));
             loadNetworkImage(item,
-                QUrl(QString("https://picsum.photos/seed/%1/180/140").arg(seeds[i])));
+                             QUrl(QString("https://picsum.photos/seed/%1/180/140").arg(seeds[i])));
             mdl->appendRow(item);
         }
         gvMultiDrag->setModel(mdl);
@@ -1803,20 +1883,18 @@ TEST_F(GridViewTest, VisualCheck) {
     gvExtDrag->setVerticalSpacing(4);
     {
         auto* mdl = new QStandardItemModel(gvExtDrag);
-        QStringList seeds = {"ivory-tower", "jade-garden", "karst-peaks",
-                             "lavender-row", "marble-arch", "nordic-wood",
-                             "opal-cave", "prairie-wind"};
+        QStringList seeds = {"ivory-tower", "jade-garden", "karst-peaks", "lavender-row",
+                             "marble-arch", "nordic-wood", "opal-cave",   "prairie-wind"};
         for (int i = 0; i < seeds.size(); ++i) {
             auto* item = new QStandardItem(QString("Tile %1").arg(i + 1));
             loadNetworkImage(item,
-                QUrl(QString("https://picsum.photos/seed/%1/180/140").arg(seeds[i])));
+                             QUrl(QString("https://picsum.photos/seed/%1/180/140").arg(seeds[i])));
             mdl->appendRow(item);
         }
         gvExtDrag->setModel(mdl);
         attachFluentDelegate(gvExtDrag);
-        gvExtDrag->selectionModel()->select(
-            QItemSelection(mdl->index(0, 0), mdl->index(2, 0)),
-            QItemSelectionModel::Select);
+        gvExtDrag->selectionModel()->select(QItemSelection(mdl->index(0, 0), mdl->index(2, 0)),
+                                            QItemSelectionModel::Select);
     }
 
     dragRowLay->addWidget(gvMultiDrag);
@@ -1824,8 +1902,8 @@ TEST_F(GridViewTest, VisualCheck) {
     dragRow->setFixedHeight(210);
     {
         AnchorLayout::Anchors a;
-        a.top   = {header6, Edge::Bottom, 8};
-        a.left  = {content, Edge::Left,  20};
+        a.top = {header6, Edge::Bottom, 8};
+        a.left = {content, Edge::Left, 20};
         a.right = {content, Edge::Right, -20};
         innerLayout->addAnchoredWidget(dragRow, a);
     }
@@ -1834,7 +1912,7 @@ TEST_F(GridViewTest, VisualCheck) {
     auto* themeBtn = new fluent::basicinput::Button("Switch Theme", content);
     themeBtn->setFluentStyle(fluent::basicinput::Button::Accent);
     themeBtn->setFixedSize(120, 32);
-    themeBtn->anchors()->top  = {dragRow, Edge::Bottom, 24};
+    themeBtn->anchors()->top = {dragRow, Edge::Bottom, 24};
     themeBtn->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(themeBtn);
 
@@ -1842,15 +1920,14 @@ TEST_F(GridViewTest, VisualCheck) {
     // loading(160) + gv1(280) + gv2 header+grid(16+20+8+300) + gv3(16+80) + gv4 header+grid(16+20+8+230)
     // + header5+modeRow1+modeRow2(24+20+8+170+8+170) + header6+dragRow(24+20+8+210)
     // + themeBtn(24+32) + margins(20+20)
-    content->setMinimumHeight(20 + 160 + 16 + 280 + 16 + 20 + 8 + 300 + 16 + 80 + 16 + 20 + 8 + 230
-                              + 24 + 20 + 8 + 170 + 8 + 170
-                              + 24 + 20 + 8 + 210
-                              + 24 + 32 + 20);
+    content->setMinimumHeight(20 + 160 + 16 + 280 + 16 + 20 + 8 + 300 + 16 + 80 + 16 + 20 + 8 +
+                              230 + 24 + 20 + 8 + 170 + 8 + 170 + 24 + 20 + 8 + 210 + 24 + 32 + 20);
 
     QObject::connect(themeBtn, &fluent::basicinput::Button::clicked, [scrollArea, content]() {
-        fluent::FluentElement::setTheme(
-            fluent::FluentElement::currentTheme() == fluent::FluentElement::Light
-                ? fluent::FluentElement::Dark : fluent::FluentElement::Light);
+        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() ==
+                                                fluent::FluentElement::Light
+                                            ? fluent::FluentElement::Dark
+                                            : fluent::FluentElement::Light);
         content->onThemeUpdated();
         scrollArea->setStyleSheet(content->styleSheet());
     });

--- a/tests/components/collections/TestGridView.cpp
+++ b/tests/components/collections/TestGridView.cpp
@@ -566,6 +566,78 @@ TEST_F(GridViewTest, ItemClickedSignal) {
     EXPECT_EQ(spy.at(0).at(0).toInt(), 0);
 }
 
+TEST_F(GridViewTest, ReorderEnabledPointerClicksPreserveInheritedSignal) {
+    window->setAttribute(Qt::WA_DontShowOnScreen, true);
+    auto* gv = new GridView(window);
+    gv->setGeometry(0, 0, 600, 400);
+    gv->setSelectionMode(SelectionMode::Multiple);
+    gv->setCanReorderItems(true);
+    attachStringListModel(gv, {"A", "B", "C"});
+    window->show();
+    QTest::qWait(50);
+
+    QSignalSpy inheritedPressSpy(gv, &QAbstractItemView::pressed);
+    QSignalSpy inheritedClickSpy(gv, &QAbstractItemView::clicked);
+    QSignalSpy itemClickSpy(gv, &GridView::itemClicked);
+    const QModelIndex index = gv->model()->index(1, 0);
+    const QPoint point = gv->visualRect(index).center();
+
+    // The first click uses QListView's normal path.
+    QTest::mouseClick(gv->viewport(), Qt::LeftButton, Qt::NoModifier, point);
+    QApplication::processEvents();
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)), index);
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)), index);
+    ASSERT_EQ(itemClickSpy.count(), 1);
+    EXPECT_EQ(itemClickSpy.at(0).at(0).toInt(), index.row());
+
+    inheritedPressSpy.clear();
+    inheritedClickSpy.clear();
+    itemClickSpy.clear();
+
+    // The second click is intercepted to preserve the selected set for a
+    // potential multi-item drag, but it is still a click when no drag occurs.
+    QTest::mouseClick(gv->viewport(), Qt::LeftButton, Qt::NoModifier, point);
+    QApplication::processEvents();
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)), index);
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)), index);
+    ASSERT_EQ(itemClickSpy.count(), 1);
+    EXPECT_EQ(itemClickSpy.at(0).at(0).toInt(), index.row());
+}
+
+TEST_F(GridViewTest, ReorderEnabledProgrammaticSelectionPreservesInheritedClick) {
+    window->setAttribute(Qt::WA_DontShowOnScreen, true);
+    auto* gv = new GridView(window);
+    gv->setGeometry(0, 0, 600, 400);
+    gv->setSelectionMode(SelectionMode::Multiple);
+    gv->setCanReorderItems(true);
+    attachStringListModel(gv, {"A", "B", "C"});
+    window->show();
+    QTest::qWait(50);
+
+    const QModelIndex index = gv->model()->index(1, 0);
+    gv->selectionModel()->select(index, QItemSelectionModel::Select);
+    ASSERT_TRUE(gv->selectionModel()->isSelected(index));
+
+    QSignalSpy inheritedPressSpy(gv, &QAbstractItemView::pressed);
+    QSignalSpy inheritedClickSpy(gv, &QAbstractItemView::clicked);
+    QSignalSpy itemClickSpy(gv, &GridView::itemClicked);
+
+    QTest::mouseClick(gv->viewport(), Qt::LeftButton, Qt::NoModifier,
+                      gv->visualRect(index).center());
+    QApplication::processEvents();
+
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)), index);
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)), index);
+    ASSERT_EQ(itemClickSpy.count(), 1);
+    EXPECT_EQ(itemClickSpy.at(0).at(0).toInt(), index.row());
+}
+
 TEST_F(GridViewTest, FluentScrollBarExists) {
     GridView* gv = new GridView(window);
     EXPECT_NE(gv->verticalFluentScrollBar(), nullptr);

--- a/tests/components/collections/TestListView.cpp
+++ b/tests/components/collections/TestListView.cpp
@@ -435,6 +435,8 @@ TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease) {
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 240, 160);
     attachStringListModel(lv, {"A", "B", "C"});
+    QSignalSpy inheritedPressSpy(lv, &QAbstractItemView::pressed);
+    QSignalSpy inheritedClickSpy(lv, &QAbstractItemView::clicked);
     QSignalSpy clickSpy(lv, SIGNAL(itemClicked(int)));
     window->show();
     QTest::qWait(50);
@@ -444,12 +446,19 @@ TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease) {
     QApplication::processEvents();
 
     EXPECT_EQ(lv->selectedIndex(), -1);
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)),
+              lv->model()->index(1, 0));
+    EXPECT_EQ(inheritedClickSpy.count(), 0);
     EXPECT_EQ(clickSpy.count(), 0);
 
     QTest::mouseRelease(lv->viewport(), Qt::LeftButton, Qt::NoModifier, point);
     QApplication::processEvents();
 
     EXPECT_EQ(lv->selectedIndex(), 1);
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)),
+              lv->model()->index(1, 0));
     ASSERT_EQ(clickSpy.count(), 1);
     EXPECT_EQ(clickSpy.at(0).at(0).toInt(), 1);
 }

--- a/tests/components/collections/TestListView.cpp
+++ b/tests/components/collections/TestListView.cpp
@@ -40,38 +40,45 @@ using namespace fluent;
 
 namespace {
 
-int defaultListRowHeight() {
+int defaultListRowHeight()
+{
     return Spacing::ControlHeight::Standard + Spacing::Gap::Tight;
 }
 
 /** 业务组装：为 ListView 挂上 Fluent 行高代理（主题来自 ListView 的
  * fluent::FluentElement）。 */
-void attachFluentDelegate(ListView* lv, int rowHeight = defaultListRowHeight()) {
+void attachFluentDelegate(ListView* lv, int rowHeight = defaultListRowHeight())
+{
     lv->setItemDelegate(new listview_test::FluentListItemDelegate(
         static_cast<fluent::FluentElement*>(lv), rowHeight, lv, lv));
     lv->setUniformItemSizes(true);
 }
 
 /** 创建 QStringListModel，setModel + attachFluentDelegate。 */
-QStringListModel* attachStringListModel(ListView* lv, const QStringList& rows = {}) {
+QStringListModel* attachStringListModel(ListView* lv, const QStringList& rows = {})
+{
     auto* m = new QStringListModel(rows, lv);
     lv->setModel(m);
     attachFluentDelegate(lv);
     return m;
 }
 
-int itemCount(ListView* lv) {
+int itemCount(ListView* lv)
+{
     const auto* m = lv->model();
     return m ? m->rowCount() : 0;
 }
 
-QString itemText(ListView* lv, int index) {
+QString itemText(ListView* lv, int index)
+{
     const auto* m = lv->model();
-    if (!m || index < 0 || index >= m->rowCount()) return {};
+    if (!m || index < 0 || index >= m->rowCount())
+        return {};
     return m->index(index, 0).data(Qt::DisplayRole).toString();
 }
 
-void addItem(ListView* lv, const QString& text) {
+void addItem(ListView* lv, const QString& text)
+{
     auto* slm = qobject_cast<QStringListModel*>(lv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -79,7 +86,8 @@ void addItem(ListView* lv, const QString& text) {
     slm->setStringList(list);
 }
 
-void addItems(ListView* lv, const QStringList& texts) {
+void addItems(ListView* lv, const QStringList& texts)
+{
     auto* slm = qobject_cast<QStringListModel*>(lv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -87,7 +95,8 @@ void addItems(ListView* lv, const QStringList& texts) {
     slm->setStringList(list);
 }
 
-void insertItem(ListView* lv, int index, const QString& text) {
+void insertItem(ListView* lv, int index, const QString& text)
+{
     auto* slm = qobject_cast<QStringListModel*>(lv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -97,7 +106,8 @@ void insertItem(ListView* lv, int index, const QString& text) {
     slm->setStringList(list);
 }
 
-void removeItem(ListView* lv, int index) {
+void removeItem(ListView* lv, int index)
+{
     auto* slm = qobject_cast<QStringListModel*>(lv->model());
     ASSERT_NE(slm, nullptr);
     QStringList list = slm->stringList();
@@ -107,7 +117,8 @@ void removeItem(ListView* lv, int index) {
     slm->setStringList(list);
 }
 
-void clearItems(ListView* lv) {
+void clearItems(ListView* lv)
+{
     auto* slm = qobject_cast<QStringListModel*>(lv->model());
     ASSERT_NE(slm, nullptr);
     slm->setStringList({});
@@ -117,7 +128,8 @@ class IndicatorListView : public ListView {
 public:
     using ListView::ListView;
 
-    QRect exposedVisualRect(int row) const {
+    QRect exposedVisualRect(int row) const
+    {
         if (!model() || row < 0 || row >= model()->rowCount())
             return {};
         return ListView::visualRect(model()->index(row, 0));
@@ -126,13 +138,9 @@ public:
 
 class RecordingStateDelegate : public QStyledItemDelegate {
 public:
-    explicit RecordingStateDelegate(QObject* parent = nullptr)
-        : QStyledItemDelegate(parent)
-    {
-    }
+    explicit RecordingStateDelegate(QObject* parent = nullptr) : QStyledItemDelegate(parent) {}
 
-    QSize sizeHint(const QStyleOptionViewItem& option,
-                   const QModelIndex& index) const override
+    QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
     {
         Q_UNUSED(option);
         Q_UNUSED(index);
@@ -147,32 +155,29 @@ public:
         QStyledItemDelegate::paint(painter, option, index);
     }
 
-    QStyle::State stateFor(int row) const
-    {
-        return m_states.value(row, QStyle::State());
-    }
+    QStyle::State stateFor(int row) const { return m_states.value(row, QStyle::State()); }
 
-    void clearStates() const
-    {
-        m_states.clear();
-    }
+    void clearStates() const { m_states.clear(); }
 
 private:
     mutable QHash<int, QStyle::State> m_states;
 };
 
-void showWindowAndProcess(QWidget* widget) {
+void showWindowAndProcess(QWidget* widget)
+{
     widget->setAttribute(Qt::WA_DontShowOnScreen, true);
     widget->show();
     QApplication::processEvents();
     QTest::qWait(50);
 }
 
-QRectF itemBackgroundRect(const IndicatorListView* lv, int row) {
+QRectF itemBackgroundRect(const IndicatorListView* lv, int row)
+{
     return QRectF(lv->exposedVisualRect(row)).adjusted(2.0, 1.0, -2.0, -1.0);
 }
 
-QImage renderViewport(QWidget* viewport) {
+QImage renderViewport(QWidget* viewport)
+{
     QImage image(viewport->size(), QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);
     QPainter painter(&image);
@@ -180,24 +185,25 @@ QImage renderViewport(QWidget* viewport) {
     return image;
 }
 
-bool isNearColor(const QColor& sample, const QColor& target, int tolerance = 72) {
-    return sample.alpha() > 96
-        && qAbs(sample.red() - target.red()) <= tolerance
-        && qAbs(sample.green() - target.green()) <= tolerance
-        && qAbs(sample.blue() - target.blue()) <= tolerance;
+bool isNearColor(const QColor& sample, const QColor& target, int tolerance = 72)
+{
+    return sample.alpha() > 96 && qAbs(sample.red() - target.red()) <= tolerance &&
+           qAbs(sample.green() - target.green()) <= tolerance &&
+           qAbs(sample.blue() - target.blue()) <= tolerance;
 }
 
 IndicatorListView* createIndicatorListView(QWidget* parent,
                                            QListView::Flow flow = QListView::TopToBottom,
-                                           const QStringList& rows = QStringList{}) {
+                                           const QStringList& rows = QStringList{})
+{
     auto* lv = new IndicatorListView(parent);
     lv->setGeometry(10, 10, 460, flow == QListView::LeftToRight ? 96 : 220);
     lv->setFlow(flow);
     lv->setWrapping(false);
     lv->setSelectedIndicatorAnimationEnabled(false);
-    attachStringListModel(lv, rows.isEmpty()
-                                  ? QStringList{"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"}
-                                  : rows);
+    attachStringListModel(
+        lv, rows.isEmpty() ? QStringList{"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"}
+                           : rows);
     return lv;
 }
 
@@ -206,7 +212,8 @@ IndicatorListView* createIndicatorListView(QWidget* parent,
 class FluentTestWindow : public QWidget, public fluent::FluentElement {
 public:
     using QWidget::QWidget;
-    void onThemeUpdated() override {
+    void onThemeUpdated() override
+    {
         const auto& c = themeColors();
         setStyleSheet(QString("background-color: %1;").arg(c.bgCanvas.name()));
     }
@@ -214,7 +221,8 @@ public:
 
 class ListViewTest : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp() override
+    {
         window = new FluentTestWindow();
         window->setFixedSize(500, 500);
         window->setWindowTitle("Fluent ListView Test");
@@ -223,9 +231,7 @@ protected:
         window->onThemeUpdated();
     }
 
-    void TearDown() override {
-        delete window;
-    }
+    void TearDown() override { delete window; }
 
     FluentTestWindow* window;
     AnchorLayout* layout;
@@ -233,7 +239,8 @@ protected:
 
 // ── 业务层：QStringListModel + Fluent delegate + 数据操作 ─────────────────────
 
-TEST_F(ListViewTest, AddAndRemoveItems) {
+TEST_F(ListViewTest, AddAndRemoveItems)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
 
@@ -254,7 +261,8 @@ TEST_F(ListViewTest, AddAndRemoveItems) {
     EXPECT_EQ(itemCount(lv), 0);
 }
 
-TEST_F(ListViewTest, AddItemsBatch) {
+TEST_F(ListViewTest, AddItemsBatch)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
     addItems(lv, {"A", "B", "C", "D"});
@@ -262,7 +270,8 @@ TEST_F(ListViewTest, AddItemsBatch) {
     EXPECT_EQ(itemText(lv, 3), "D");
 }
 
-TEST_F(ListViewTest, InsertItem) {
+TEST_F(ListViewTest, InsertItem)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
     addItems(lv, {"A", "C"});
@@ -273,7 +282,8 @@ TEST_F(ListViewTest, InsertItem) {
     EXPECT_EQ(itemText(lv, 2), "C");
 }
 
-TEST_F(ListViewTest, ItemTextOutOfRange) {
+TEST_F(ListViewTest, ItemTextOutOfRange)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
     addItem(lv, "Only");
@@ -283,17 +293,20 @@ TEST_F(ListViewTest, ItemTextOutOfRange) {
 
 // ── 视图：选择模式 ────────────────────────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultSelectionMode) {
+TEST_F(ListViewTest, DefaultSelectionMode)
+{
     ListView* lv = new ListView(window);
     EXPECT_EQ(lv->selectionMode(), SelectionMode::Single);
 }
 
-TEST_F(ListViewTest, DefaultEditTriggersDisabled) {
+TEST_F(ListViewTest, DefaultEditTriggersDisabled)
+{
     ListView* lv = new ListView(window);
     EXPECT_EQ(lv->editTriggers(), QAbstractItemView::NoEditTriggers);
 }
 
-TEST_F(ListViewTest, SelectionModeRegisteredInMetaObject) {
+TEST_F(ListViewTest, SelectionModeRegisteredInMetaObject)
+{
     QMetaEnum me = QMetaEnum::fromType<SelectionMode>();
     ASSERT_TRUE(me.isValid());
     EXPECT_STREQ(me.key(0), "None");
@@ -302,14 +315,16 @@ TEST_F(ListViewTest, SelectionModeRegisteredInMetaObject) {
     EXPECT_STREQ(me.key(3), "Extended");
 }
 
-TEST_F(ListViewTest, SelectionModeNone) {
+TEST_F(ListViewTest, SelectionModeNone)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv, {"A", "B", "C"});
     lv->setSelectionMode(SelectionMode::None);
     EXPECT_EQ(lv->selectionMode(), SelectionMode::None);
 }
 
-TEST_F(ListViewTest, SelectionModeMultiple) {
+TEST_F(ListViewTest, SelectionModeMultiple)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, SIGNAL(selectionModeChanged()));
     lv->setSelectionMode(SelectionMode::Multiple);
@@ -320,7 +335,8 @@ TEST_F(ListViewTest, SelectionModeMultiple) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, SelectionModeExtended) {
+TEST_F(ListViewTest, SelectionModeExtended)
+{
     ListView* lv = new ListView(window);
     lv->setSelectionMode(SelectionMode::Extended);
     EXPECT_EQ(lv->selectionMode(), SelectionMode::Extended);
@@ -328,7 +344,8 @@ TEST_F(ListViewTest, SelectionModeExtended) {
 
 // ── 选中 API（依赖已 setModel）────────────────────────────────────────────────
 
-TEST_F(ListViewTest, SingleSelection) {
+TEST_F(ListViewTest, SingleSelection)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv, {"A", "B", "C"});
 
@@ -341,7 +358,8 @@ TEST_F(ListViewTest, SingleSelection) {
     EXPECT_EQ(lv->selectedIndex(), -1);
 }
 
-TEST_F(ListViewTest, SelectedIndexOutOfRange) {
+TEST_F(ListViewTest, SelectedIndexOutOfRange)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv, {"A", "B"});
     lv->setSelectedIndex(1);
@@ -351,7 +369,8 @@ TEST_F(ListViewTest, SelectedIndexOutOfRange) {
     EXPECT_EQ(lv->selectedIndex(), -1);
 }
 
-TEST_F(ListViewTest, SelectedRowsSortedAscending) {
+TEST_F(ListViewTest, SelectedRowsSortedAscending)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv, {"A", "B", "C", "D"});
     lv->setSelectionMode(SelectionMode::Multiple);
@@ -367,7 +386,8 @@ TEST_F(ListViewTest, SelectedRowsSortedAscending) {
     EXPECT_EQ(rows.at(1), 2);
 }
 
-TEST_F(ListViewTest, ViewportHoveredSignal) {
+TEST_F(ListViewTest, ViewportHoveredSignal)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 200, 200);
@@ -388,12 +408,14 @@ TEST_F(ListViewTest, ViewportHoveredSignal) {
 
 // ── 视图默认属性 / 业务 delegate 行高 ──────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultFontRole) {
+TEST_F(ListViewTest, DefaultFontRole)
+{
     ListView* lv = new ListView(window);
     EXPECT_EQ(lv->fontRole(), Typography::FontRole::Body);
 }
 
-TEST_F(ListViewTest, FluentDelegateDefaultRowHeight) {
+TEST_F(ListViewTest, FluentDelegateDefaultRowHeight)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
     auto* del = qobject_cast<listview_test::FluentListItemDelegate*>(lv->itemDelegate());
@@ -401,7 +423,8 @@ TEST_F(ListViewTest, FluentDelegateDefaultRowHeight) {
     EXPECT_EQ(del->rowHeight(), defaultListRowHeight());
 }
 
-TEST_F(ListViewTest, FluentDelegateSetRowHeight) {
+TEST_F(ListViewTest, FluentDelegateSetRowHeight)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv);
     auto* del = qobject_cast<listview_test::FluentListItemDelegate*>(lv->itemDelegate());
@@ -411,7 +434,8 @@ TEST_F(ListViewTest, FluentDelegateSetRowHeight) {
     EXPECT_EQ(del->rowHeight(), 48);
 }
 
-TEST_F(ListViewTest, SetFontRole) {
+TEST_F(ListViewTest, SetFontRole)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, SIGNAL(fontRoleChanged()));
     lv->setFontRole(Typography::FontRole::Subtitle);
@@ -419,7 +443,8 @@ TEST_F(ListViewTest, SetFontRole) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, ItemClickedSignal) {
+TEST_F(ListViewTest, ItemClickedSignal)
+{
     ListView* lv = new ListView(window);
     attachStringListModel(lv, {"A", "B", "C"});
     QSignalSpy spy(lv, SIGNAL(itemClicked(int)));
@@ -430,7 +455,8 @@ TEST_F(ListViewTest, ItemClickedSignal) {
     EXPECT_EQ(spy.at(0).at(0).toInt(), 0);
 }
 
-TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease) {
+TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 240, 160);
@@ -447,8 +473,7 @@ TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease) {
 
     EXPECT_EQ(lv->selectedIndex(), -1);
     ASSERT_EQ(inheritedPressSpy.count(), 1);
-    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)),
-              lv->model()->index(1, 0));
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedPressSpy.at(0).at(0)), lv->model()->index(1, 0));
     EXPECT_EQ(inheritedClickSpy.count(), 0);
     EXPECT_EQ(clickSpy.count(), 0);
 
@@ -457,13 +482,13 @@ TEST_F(ListViewTest, MousePressDefersSelectionUntilRelease) {
 
     EXPECT_EQ(lv->selectedIndex(), 1);
     ASSERT_EQ(inheritedClickSpy.count(), 1);
-    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)),
-              lv->model()->index(1, 0));
+    EXPECT_EQ(qvariant_cast<QModelIndex>(inheritedClickSpy.at(0).at(0)), lv->model()->index(1, 0));
     ASSERT_EQ(clickSpy.count(), 1);
     EXPECT_EQ(clickSpy.at(0).at(0).toInt(), 1);
 }
 
-TEST_F(ListViewTest, PressedPointerMoveUpdatesHoverVisualState) {
+TEST_F(ListViewTest, PressedPointerMoveUpdatesHoverVisualState)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 240, 180);
@@ -485,8 +510,8 @@ TEST_F(ListViewTest, PressedPointerMoveUpdatesHoverVisualState) {
     EXPECT_TRUE(delegate->stateFor(1) & QStyle::State_Sunken);
 
     delegate->clearStates();
-    FLUENT_MAKE_MOUSE_EVENT(moveEvent, QEvent::MouseMove, lv->viewport(), row2,
-                            Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    FLUENT_MAKE_MOUSE_EVENT(moveEvent, QEvent::MouseMove, lv->viewport(), row2, Qt::NoButton,
+                            Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(lv->viewport(), &moveEvent);
     lv->viewport()->update();
     QApplication::processEvents();
@@ -497,7 +522,8 @@ TEST_F(ListViewTest, PressedPointerMoveUpdatesHoverVisualState) {
     QTest::mouseRelease(lv->viewport(), Qt::LeftButton, Qt::NoModifier, row2);
 }
 
-TEST_F(ListViewTest, MultiplePointerSelectionTogglesRowsOnRelease) {
+TEST_F(ListViewTest, MultiplePointerSelectionTogglesRowsOnRelease)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 240, 180);
@@ -522,34 +548,35 @@ TEST_F(ListViewTest, MultiplePointerSelectionTogglesRowsOnRelease) {
     EXPECT_EQ(lv->selectedRows(), QList<int>({3}));
 }
 
-TEST_F(ListViewTest, PointerSelectionIgnoresDisabledRows) {
-  window->setAttribute(Qt::WA_DontShowOnScreen, true);
-  auto *lv = new IndicatorListView(window);
-  lv->setGeometry(10, 10, 240, 160);
-  lv->setSelectionMode(SelectionMode::Multiple);
-  auto *model = new QStandardItemModel(lv);
-  model->appendRow(new QStandardItem(QStringLiteral("Enabled")));
-  auto *disabled = new QStandardItem(QStringLiteral("Disabled"));
-  disabled->setFlags(disabled->flags() & ~Qt::ItemIsEnabled &
-                     ~Qt::ItemIsSelectable);
-  model->appendRow(disabled);
-  lv->setModel(model);
-  attachFluentDelegate(lv);
-  window->show();
-  QTest::qWait(50);
+TEST_F(ListViewTest, PointerSelectionIgnoresDisabledRows)
+{
+    window->setAttribute(Qt::WA_DontShowOnScreen, true);
+    auto* lv = new IndicatorListView(window);
+    lv->setGeometry(10, 10, 240, 160);
+    lv->setSelectionMode(SelectionMode::Multiple);
+    auto* model = new QStandardItemModel(lv);
+    model->appendRow(new QStandardItem(QStringLiteral("Enabled")));
+    auto* disabled = new QStandardItem(QStringLiteral("Disabled"));
+    disabled->setFlags(disabled->flags() & ~Qt::ItemIsEnabled & ~Qt::ItemIsSelectable);
+    model->appendRow(disabled);
+    lv->setModel(model);
+    attachFluentDelegate(lv);
+    window->show();
+    QTest::qWait(50);
 
-  QTest::mouseClick(lv->viewport(), Qt::LeftButton, Qt::NoModifier,
-                    lv->exposedVisualRect(1).center());
-  QApplication::processEvents();
-  EXPECT_TRUE(lv->selectedRows().isEmpty());
+    QTest::mouseClick(lv->viewport(), Qt::LeftButton, Qt::NoModifier,
+                      lv->exposedVisualRect(1).center());
+    QApplication::processEvents();
+    EXPECT_TRUE(lv->selectedRows().isEmpty());
 
-  QTest::mouseClick(lv->viewport(), Qt::LeftButton, Qt::NoModifier,
-                    lv->exposedVisualRect(0).center());
-  QApplication::processEvents();
-  EXPECT_EQ(lv->selectedRows(), QList<int>({0}));
+    QTest::mouseClick(lv->viewport(), Qt::LeftButton, Qt::NoModifier,
+                      lv->exposedVisualRect(0).center());
+    QApplication::processEvents();
+    EXPECT_EQ(lv->selectedRows(), QList<int>({0}));
 }
 
-TEST_F(ListViewTest, ExtendedPointerSelectionSupportsControlAndShift) {
+TEST_F(ListViewTest, ExtendedPointerSelectionSupportsControlAndShift)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 240, 220);
@@ -574,12 +601,14 @@ TEST_F(ListViewTest, ExtendedPointerSelectionSupportsControlAndShift) {
     EXPECT_EQ(lv->selectedRows(), QList<int>({1, 3}));
 }
 
-TEST_F(ListViewTest, FluentScrollBarExists) {
+TEST_F(ListViewTest, FluentScrollBarExists)
+{
     ListView* lv = new ListView(window);
     EXPECT_NE(lv->verticalFluentScrollBar(), nullptr);
 }
 
-TEST_F(ListViewTest, CustomModelWithFluentDelegate) {
+TEST_F(ListViewTest, CustomModelWithFluentDelegate)
+{
     ListView* lv = new ListView(window);
     auto* stdModel = new QStandardItemModel(lv);
     stdModel->appendRow(new QStandardItem("Row0"));
@@ -594,7 +623,8 @@ TEST_F(ListViewTest, CustomModelWithFluentDelegate) {
     EXPECT_EQ(lv->selectedIndex(), 1);
 }
 
-TEST_F(ListViewTest, ViewDoesNotProvideModelByDefault) {
+TEST_F(ListViewTest, ViewDoesNotProvideModelByDefault)
+{
     ListView* lv = new ListView(window);
     EXPECT_EQ(lv->model(), nullptr);
     // Qt 会为 QAbstractItemView 提供默认 itemDelegate()，故不断言 delegate 为空。
@@ -602,13 +632,15 @@ TEST_F(ListViewTest, ViewDoesNotProvideModelByDefault) {
 
 // ── 新增属性: borderVisible / headerText / placeholderText ────────────────────
 
-TEST_F(ListViewTest, DefaultBorderVisible) {
+TEST_F(ListViewTest, DefaultBorderVisible)
+{
     ListView* lv = new ListView(window);
     EXPECT_TRUE(lv->borderVisible());
     EXPECT_TRUE(lv->isBorderVisible());
 }
 
-TEST_F(ListViewTest, SetBorderVisible) {
+TEST_F(ListViewTest, SetBorderVisible)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::borderVisibleChanged);
     lv->setBorderVisible(false);
@@ -621,12 +653,14 @@ TEST_F(ListViewTest, SetBorderVisible) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, DefaultHeaderText) {
+TEST_F(ListViewTest, DefaultHeaderText)
+{
     ListView* lv = new ListView(window);
     EXPECT_TRUE(lv->headerText().isEmpty());
 }
 
-TEST_F(ListViewTest, SetHeaderText) {
+TEST_F(ListViewTest, SetHeaderText)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::headerTextChanged);
     lv->setHeaderText("My Header");
@@ -638,12 +672,14 @@ TEST_F(ListViewTest, SetHeaderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, DefaultPlaceholderText) {
+TEST_F(ListViewTest, DefaultPlaceholderText)
+{
     ListView* lv = new ListView(window);
     EXPECT_TRUE(lv->placeholderText().isEmpty());
 }
 
-TEST_F(ListViewTest, SetPlaceholderText) {
+TEST_F(ListViewTest, SetPlaceholderText)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::placeholderTextChanged);
     lv->setPlaceholderText("No items");
@@ -654,7 +690,8 @@ TEST_F(ListViewTest, SetPlaceholderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, HeaderVisibleWhenTextSet) {
+TEST_F(ListViewTest, HeaderVisibleWhenTextSet)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 200);
@@ -667,7 +704,8 @@ TEST_F(ListViewTest, HeaderVisibleWhenTextSet) {
     EXPECT_EQ(headerLabel->text(), "Header");
 }
 
-TEST_F(ListViewTest, HeaderHiddenWhenTextEmpty) {
+TEST_F(ListViewTest, HeaderHiddenWhenTextEmpty)
+{
     ListView* lv = new ListView(window);
     lv->setHeaderText("Header");
     lv->setHeaderText("");
@@ -675,7 +713,8 @@ TEST_F(ListViewTest, HeaderHiddenWhenTextEmpty) {
     EXPECT_EQ(lv->header(), nullptr);
 }
 
-TEST_F(ListViewTest, SetCustomHeader) {
+TEST_F(ListViewTest, SetCustomHeader)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 200);
@@ -698,7 +737,8 @@ TEST_F(ListViewTest, SetCustomHeader) {
     EXPECT_EQ(spy.count(), 2);
 }
 
-TEST_F(ListViewTest, SetCustomFooter) {
+TEST_F(ListViewTest, SetCustomFooter)
+{
     ListView* lv = new ListView(window);
 
     EXPECT_EQ(lv->footer(), nullptr);
@@ -712,7 +752,8 @@ TEST_F(ListViewTest, SetCustomFooter) {
     EXPECT_EQ(custom->parentWidget(), lv);
 }
 
-TEST_F(ListViewTest, SetHeaderReplacesTextHeader) {
+TEST_F(ListViewTest, SetHeaderReplacesTextHeader)
+{
     ListView* lv = new ListView(window);
     lv->setHeaderText("Text Header");
     EXPECT_NE(lv->header(), nullptr);
@@ -727,12 +768,14 @@ TEST_F(ListViewTest, SetHeaderReplacesTextHeader) {
 
 // ── Flow 属性 ─────────────────────────────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultFlowIsTopToBottom) {
+TEST_F(ListViewTest, DefaultFlowIsTopToBottom)
+{
     ListView* lv = new ListView(window);
     EXPECT_EQ(lv->flow(), QListView::TopToBottom);
 }
 
-TEST_F(ListViewTest, SetFlowLeftToRight) {
+TEST_F(ListViewTest, SetFlowLeftToRight)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::flowChanged);
     lv->setFlow(QListView::LeftToRight);
@@ -744,19 +787,22 @@ TEST_F(ListViewTest, SetFlowLeftToRight) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, SetFlowBackToTopToBottom) {
+TEST_F(ListViewTest, SetFlowBackToTopToBottom)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setFlow(QListView::TopToBottom);
     EXPECT_EQ(lv->flow(), QListView::TopToBottom);
 }
 
-TEST_F(ListViewTest, HorizontalFluentScrollBarExists) {
+TEST_F(ListViewTest, HorizontalFluentScrollBarExists)
+{
     ListView* lv = new ListView(window);
     EXPECT_NE(lv->horizontalFluentScrollBar(), nullptr);
 }
 
-TEST_F(ListViewTest, HorizontalFlowSelection) {
+TEST_F(ListViewTest, HorizontalFlowSelection)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"A", "B", "C", "D"});
@@ -765,7 +811,8 @@ TEST_F(ListViewTest, HorizontalFlowSelection) {
     EXPECT_EQ(itemText(lv, 2), "C");
 }
 
-TEST_F(ListViewTest, HorizontalFlowAddRemoveItems) {
+TEST_F(ListViewTest, HorizontalFlowAddRemoveItems)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv);
@@ -779,7 +826,8 @@ TEST_F(ListViewTest, HorizontalFlowAddRemoveItems) {
     EXPECT_EQ(itemText(lv, 1), "Z");
 }
 
-TEST_F(ListViewTest, HorizontalFlowMultipleSelection) {
+TEST_F(ListViewTest, HorizontalFlowMultipleSelection)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setSelectionMode(SelectionMode::Multiple);
@@ -796,14 +844,15 @@ TEST_F(ListViewTest, HorizontalFlowMultipleSelection) {
     EXPECT_EQ(rows.at(1), 3);
 }
 
-TEST_F(ListViewTest, HorizontalScrollBarVisibleWhenNeeded) {
+TEST_F(ListViewTest, HorizontalScrollBarVisibleWhenNeeded)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setFixedSize(100, 60);
     // Use uniform item sizes for horizontal items
-    auto* m = new QStringListModel({"AAAA", "BBBB", "CCCC", "DDDD", "EEEE",
-                                     "FFFF", "GGGG", "HHHH", "IIII", "JJJJ"}, lv);
+    auto* m = new QStringListModel(
+        {"AAAA", "BBBB", "CCCC", "DDDD", "EEEE", "FFFF", "GGGG", "HHHH", "IIII", "JJJJ"}, lv);
     lv->setModel(m);
     layout->addWidget(lv);
     window->show();
@@ -818,7 +867,8 @@ TEST_F(ListViewTest, HorizontalScrollBarVisibleWhenNeeded) {
     }
 }
 
-TEST_F(ListViewTest, BackgroundVisibleProperty) {
+TEST_F(ListViewTest, BackgroundVisibleProperty)
+{
     ListView* lv = new ListView(window);
     EXPECT_TRUE(lv->backgroundVisible());
     EXPECT_TRUE(lv->isBackgroundVisible());
@@ -831,7 +881,8 @@ TEST_F(ListViewTest, BackgroundVisibleProperty) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, CompositedClearHonorsPreserveParentSurface) {
+TEST_F(ListViewTest, CompositedClearHonorsPreserveParentSurface)
+{
     window->setAttribute(Qt::WA_TranslucentBackground, true);
 
     fluent::windowing::BackdropState state;
@@ -862,7 +913,8 @@ TEST_F(ListViewTest, CompositedClearHonorsPreserveParentSurface) {
     EXPECT_FALSE(detail::shouldClearCompositedViewport(lv));
 }
 
-TEST_F(ListViewTest, FlowChangeRefreshesScrollBars) {
+TEST_F(ListViewTest, FlowChangeRefreshesScrollBars)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setFixedSize(200, 200);
@@ -880,7 +932,8 @@ TEST_F(ListViewTest, FlowChangeRefreshesScrollBars) {
     QTest::qWait(50);
 }
 
-TEST_F(ListViewTest, HorizontalFlowInsertItem) {
+TEST_F(ListViewTest, HorizontalFlowInsertItem)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"A", "C"});
@@ -891,7 +944,8 @@ TEST_F(ListViewTest, HorizontalFlowInsertItem) {
     EXPECT_EQ(itemText(lv, 2), "C");
 }
 
-TEST_F(ListViewTest, HorizontalFlowClearItems) {
+TEST_F(ListViewTest, HorizontalFlowClearItems)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"A", "B", "C"});
@@ -900,7 +954,8 @@ TEST_F(ListViewTest, HorizontalFlowClearItems) {
     EXPECT_EQ(itemCount(lv), 0);
 }
 
-TEST_F(ListViewTest, HorizontalFlowPlaceholder) {
+TEST_F(ListViewTest, HorizontalFlowPlaceholder)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setPlaceholderText("No horizontal items");
@@ -909,7 +964,8 @@ TEST_F(ListViewTest, HorizontalFlowPlaceholder) {
     EXPECT_EQ(itemCount(lv), 0);
 }
 
-TEST_F(ListViewTest, HorizontalFlowBorderVisible) {
+TEST_F(ListViewTest, HorizontalFlowBorderVisible)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     EXPECT_TRUE(lv->borderVisible());
@@ -917,7 +973,8 @@ TEST_F(ListViewTest, HorizontalFlowBorderVisible) {
     EXPECT_FALSE(lv->borderVisible());
 }
 
-TEST_F(ListViewTest, HorizontalFlowHeaderText) {
+TEST_F(ListViewTest, HorizontalFlowHeaderText)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
@@ -931,7 +988,8 @@ TEST_F(ListViewTest, HorizontalFlowHeaderText) {
     EXPECT_TRUE(headerLabel->isVisible());
 }
 
-TEST_F(ListViewTest, HorizontalFlowSelectedIndex) {
+TEST_F(ListViewTest, HorizontalFlowSelectedIndex)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"A", "B", "C", "D"});
@@ -947,7 +1005,8 @@ TEST_F(ListViewTest, HorizontalFlowSelectedIndex) {
     EXPECT_EQ(lv->selectedIndex(), -1);
 }
 
-TEST_F(ListViewTest, HorizontalFlowExtendedSelection) {
+TEST_F(ListViewTest, HorizontalFlowExtendedSelection)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setSelectionMode(SelectionMode::Extended);
@@ -955,7 +1014,8 @@ TEST_F(ListViewTest, HorizontalFlowExtendedSelection) {
     EXPECT_EQ(lv->selectionMode(), SelectionMode::Extended);
 }
 
-TEST_F(ListViewTest, HorizontalFlowNoSelection) {
+TEST_F(ListViewTest, HorizontalFlowNoSelection)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     lv->setSelectionMode(SelectionMode::None);
@@ -963,7 +1023,8 @@ TEST_F(ListViewTest, HorizontalFlowNoSelection) {
     EXPECT_EQ(lv->selectionMode(), SelectionMode::None);
 }
 
-TEST_F(ListViewTest, HorizontalFlowDelegateSizeHintHasWidth) {
+TEST_F(ListViewTest, HorizontalFlowDelegateSizeHintHasWidth)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"Hello World"});
@@ -979,7 +1040,8 @@ TEST_F(ListViewTest, HorizontalFlowDelegateSizeHintHasWidth) {
     EXPECT_GT(hint.height(), 0);
 }
 
-TEST_F(ListViewTest, HorizontalFlowItemClickedSignal) {
+TEST_F(ListViewTest, HorizontalFlowItemClickedSignal)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     attachStringListModel(lv, {"A", "B", "C"});
@@ -991,7 +1053,8 @@ TEST_F(ListViewTest, HorizontalFlowItemClickedSignal) {
     EXPECT_EQ(spy.at(0).at(0).toInt(), 1);
 }
 
-TEST_F(ListViewTest, HorizontalFlowWrapping) {
+TEST_F(ListViewTest, HorizontalFlowWrapping)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
@@ -1005,7 +1068,8 @@ TEST_F(ListViewTest, HorizontalFlowWrapping) {
     EXPECT_EQ(itemCount(lv), 8);
 }
 
-TEST_F(ListViewTest, HorizontalFlowViewportHover) {
+TEST_F(ListViewTest, HorizontalFlowViewportHover)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
@@ -1026,7 +1090,8 @@ TEST_F(ListViewTest, HorizontalFlowViewportHover) {
     EXPECT_EQ(spy.count(), 2);
 }
 
-TEST_F(ListViewTest, HorizontalFlowCustomModel) {
+TEST_F(ListViewTest, HorizontalFlowCustomModel)
+{
     ListView* lv = new ListView(window);
     lv->setFlow(QListView::LeftToRight);
     auto* stdModel = new QStandardItemModel(lv);
@@ -1041,7 +1106,8 @@ TEST_F(ListViewTest, HorizontalFlowCustomModel) {
     EXPECT_EQ(lv->selectedIndex(), 2);
 }
 
-TEST_F(ListViewTest, DefaultDelegateKeepsTextClearOfSelectionIndicator) {
+TEST_F(ListViewTest, DefaultDelegateKeepsTextClearOfSelectionIndicator)
+{
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 460, 160);
     lv->setSelectedIndicatorAnimationEnabled(false);
@@ -1071,12 +1137,13 @@ TEST_F(ListViewTest, DefaultDelegateKeepsTextClearOfSelectionIndicator) {
     ASSERT_GE(firstTextPixelX, 0);
     EXPECT_GE(firstTextPixelX - indicator.right(), 6.0)
         << "Default ListView text must not collide with the 3 px selection "
-         "indicator";
+           "indicator";
 }
 
 // ── Selected indicator motion ────────────────────────────────────────────────
 
-TEST_F(ListViewTest, SelectedIndicatorVerticalPlacement) {
+TEST_F(ListViewTest, SelectedIndicatorVerticalPlacement)
+{
     auto* lv = createIndicatorListView(window);
     showWindowAndProcess(window);
 
@@ -1094,17 +1161,15 @@ TEST_F(ListViewTest, SelectedIndicatorVerticalPlacement) {
 
 TEST_F(ListViewTest, Contract_SelectedIndicatorPaintsAccentInLightAndDark)
 {
-    const FluentElement::Theme themes[]{FluentElement::Light,
-                                        FluentElement::Dark};
+    const FluentElement::Theme themes[]{FluentElement::Light, FluentElement::Dark};
     for (const auto theme : themes) {
         FluentElement::setTheme(theme);
         auto* listView = createIndicatorListView(window);
         listView->setSelectedIndex(1);
         showWindowAndProcess(window);
 
-        const QRect indicatorRect = listView->selectedIndicatorRect()
-                                        .toAlignedRect()
-                                        .adjusted(-1, -1, 1, 1);
+        const QRect indicatorRect =
+            listView->selectedIndicatorRect().toAlignedRect().adjusted(-1, -1, 1, 1);
         const QImage image = renderViewport(listView->viewport());
         ASSERT_FALSE(image.isNull()) << "theme=" << theme;
 
@@ -1150,7 +1215,8 @@ TEST_F(ListViewTest, Contract_SelectionIndicatorVisibilityKeepsSelection)
     EXPECT_EQ(visibleSpy.count(), 1);
 }
 
-TEST_F(ListViewTest, SelectedIndicatorHorizontalPlacement) {
+TEST_F(ListViewTest, SelectedIndicatorHorizontalPlacement)
+{
     auto* lv = createIndicatorListView(window, QListView::LeftToRight);
     showWindowAndProcess(window);
 
@@ -1167,7 +1233,8 @@ TEST_F(ListViewTest, SelectedIndicatorHorizontalPlacement) {
     EXPECT_NEAR(indicator.bottom(), bg.bottom() - 4.0, 0.75);
 }
 
-TEST_F(ListViewTest, SelectedIndicatorVerticalDirectionAwareGeometry) {
+TEST_F(ListViewTest, SelectedIndicatorVerticalDirectionAwareGeometry)
+{
     auto* lv = createIndicatorListView(window);
     showWindowAndProcess(window);
 
@@ -1194,7 +1261,8 @@ TEST_F(ListViewTest, SelectedIndicatorVerticalDirectionAwareGeometry) {
     EXPECT_GT(upMid.height(), upTarget.height());
 }
 
-TEST_F(ListViewTest, SelectedIndicatorHorizontalDirectionAwareGeometry) {
+TEST_F(ListViewTest, SelectedIndicatorHorizontalDirectionAwareGeometry)
+{
     auto* lv = createIndicatorListView(window, QListView::LeftToRight);
     showWindowAndProcess(window);
 
@@ -1221,7 +1289,8 @@ TEST_F(ListViewTest, SelectedIndicatorHorizontalDirectionAwareGeometry) {
     EXPECT_GT(leftMid.width(), leftTarget.width());
 }
 
-TEST_F(ListViewTest, SelectedIndicatorTracksSelectionSources) {
+TEST_F(ListViewTest, SelectedIndicatorTracksSelectionSources)
+{
     auto* lv = createIndicatorListView(window);
     showWindowAndProcess(window);
 
@@ -1236,7 +1305,8 @@ TEST_F(ListViewTest, SelectedIndicatorTracksSelectionSources) {
     expectIndicatorOnRow(1);
 
     const QModelIndex directIndex = lv->model()->index(4, 0);
-    lv->selectionModel()->select(directIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    lv->selectionModel()->select(directIndex,
+                                 QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
     QApplication::processEvents();
     EXPECT_EQ(lv->selectedIndex(), 4);
     expectIndicatorOnRow(4);
@@ -1255,7 +1325,8 @@ TEST_F(ListViewTest, SelectedIndicatorTracksSelectionSources) {
     expectIndicatorOnRow(3);
 }
 
-TEST_F(ListViewTest, MultiSelectionUsesPerItemRevealIndicators) {
+TEST_F(ListViewTest, MultiSelectionUsesPerItemRevealIndicators)
+{
     auto* lv = createIndicatorListView(window);
     lv->setSelectionMode(SelectionMode::Multiple);
     showWindowAndProcess(window);
@@ -1286,13 +1357,16 @@ TEST_F(ListViewTest, MultiSelectionUsesPerItemRevealIndicators) {
     EXPECT_FALSE(lv->selectedIndicatorRectForRow(3).isEmpty());
 }
 
-TEST_F(ListViewTest, HorizontalMultiSelectionUsesBottomRevealIndicators) {
+TEST_F(ListViewTest, HorizontalMultiSelectionUsesBottomRevealIndicators)
+{
     auto* lv = createIndicatorListView(window, QListView::LeftToRight);
     lv->setSelectionMode(SelectionMode::Multiple);
     showWindowAndProcess(window);
 
-    lv->selectionModel()->select(lv->model()->index(0, 0), QItemSelectionModel::Select | QItemSelectionModel::Rows);
-    lv->selectionModel()->select(lv->model()->index(2, 0), QItemSelectionModel::Select | QItemSelectionModel::Rows);
+    lv->selectionModel()->select(lv->model()->index(0, 0),
+                                 QItemSelectionModel::Select | QItemSelectionModel::Rows);
+    lv->selectionModel()->select(lv->model()->index(2, 0),
+                                 QItemSelectionModel::Select | QItemSelectionModel::Rows);
     QApplication::processEvents();
 
     const QRectF full = lv->selectedIndicatorRectForRow(0, 1.0);
@@ -1306,7 +1380,8 @@ TEST_F(ListViewTest, HorizontalMultiSelectionUsesBottomRevealIndicators) {
     EXPECT_TRUE(lv->selectedIndicatorRectForRow(1).isEmpty());
 }
 
-TEST_F(ListViewTest, SelectedIndicatorFirstSelectionClearingAndEmptyModel) {
+TEST_F(ListViewTest, SelectedIndicatorFirstSelectionClearingAndEmptyModel)
+{
     auto* lv = createIndicatorListView(window);
     showWindowAndProcess(window);
 
@@ -1324,7 +1399,8 @@ TEST_F(ListViewTest, SelectedIndicatorFirstSelectionClearingAndEmptyModel) {
     EXPECT_TRUE(lv->selectedIndicatorRect().isEmpty());
 }
 
-TEST_F(ListViewTest, SelectedIndicatorRefreshesOnLayoutAndThemeChanges) {
+TEST_F(ListViewTest, SelectedIndicatorRefreshesOnLayoutAndThemeChanges)
+{
     QStringList rows;
     for (int i = 0; i < 30; ++i)
         rows << QStringLiteral("Item %1").arg(i);
@@ -1344,8 +1420,8 @@ TEST_F(ListViewTest, SelectedIndicatorRefreshesOnLayoutAndThemeChanges) {
     EXPECT_NEAR(afterResize.left(), beforeResize.left(), 0.75);
 
     if (lv->verticalScrollBar()->maximum() > 0) {
-        lv->verticalScrollBar()->setValue(qMin(lv->verticalScrollBar()->maximum(),
-                                               lv->verticalScrollBar()->value() + 6));
+        lv->verticalScrollBar()->setValue(
+            qMin(lv->verticalScrollBar()->maximum(), lv->verticalScrollBar()->value() + 6));
         QApplication::processEvents();
         EXPECT_FALSE(lv->selectedIndicatorRect().isEmpty());
     }
@@ -1360,14 +1436,17 @@ TEST_F(ListViewTest, SelectedIndicatorRefreshesOnLayoutAndThemeChanges) {
     EXPECT_EQ(lv->selectedIndicatorMotionDirection(), ListView::IndicatorMotionDirection::None);
 
     const auto previousTheme = fluent::FluentElement::currentTheme();
-    fluent::FluentElement::setTheme(previousTheme == fluent::FluentElement::Light ? fluent::FluentElement::Dark : fluent::FluentElement::Light);
+    fluent::FluentElement::setTheme(previousTheme == fluent::FluentElement::Light
+                                        ? fluent::FluentElement::Dark
+                                        : fluent::FluentElement::Light);
     QApplication::processEvents();
     EXPECT_FALSE(lv->selectedIndicatorRect().isEmpty());
     fluent::FluentElement::setTheme(previousTheme);
     QApplication::processEvents();
 }
 
-TEST_F(ListViewTest, SelectedIndicatorSettlesAfterDragReorder) {
+TEST_F(ListViewTest, SelectedIndicatorSettlesAfterDragReorder)
+{
     auto* lv = new IndicatorListView(window);
     lv->setGeometry(10, 10, 320, 220);
     lv->setCanReorderItems(true);
@@ -1398,12 +1477,14 @@ TEST_F(ListViewTest, SelectedIndicatorSettlesAfterDragReorder) {
 
 // ── Footer tests ──────────────────────────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultFooterText) {
+TEST_F(ListViewTest, DefaultFooterText)
+{
     ListView* lv = new ListView(window);
     EXPECT_TRUE(lv->footerText().isEmpty());
 }
 
-TEST_F(ListViewTest, SetFooterText) {
+TEST_F(ListViewTest, SetFooterText)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::footerTextChanged);
     lv->setFooterText("Total: 5 items");
@@ -1411,7 +1492,8 @@ TEST_F(ListViewTest, SetFooterText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, FooterVisibleWhenTextSet) {
+TEST_F(ListViewTest, FooterVisibleWhenTextSet)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 250);
@@ -1426,7 +1508,8 @@ TEST_F(ListViewTest, FooterVisibleWhenTextSet) {
     EXPECT_EQ(footerLabel->text(), "Footer");
 }
 
-TEST_F(ListViewTest, FooterHiddenWhenTextEmpty) {
+TEST_F(ListViewTest, FooterHiddenWhenTextEmpty)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 250);
@@ -1436,7 +1519,8 @@ TEST_F(ListViewTest, FooterHiddenWhenTextEmpty) {
     EXPECT_EQ(lv->footer(), nullptr);
 }
 
-TEST_F(ListViewTest, FooterSignalNotDuplicate) {
+TEST_F(ListViewTest, FooterSignalNotDuplicate)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::footerTextChanged);
     lv->setFooterText("A");
@@ -1446,12 +1530,14 @@ TEST_F(ListViewTest, FooterSignalNotDuplicate) {
 
 // ── Drag reorder tests ────────────────────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultCanReorderItems) {
+TEST_F(ListViewTest, DefaultCanReorderItems)
+{
     ListView* lv = new ListView(window);
     EXPECT_FALSE(lv->canReorderItems());
 }
 
-TEST_F(ListViewTest, SetCanReorderItems) {
+TEST_F(ListViewTest, SetCanReorderItems)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::canReorderItemsChanged);
     lv->setCanReorderItems(true);
@@ -1459,14 +1545,16 @@ TEST_F(ListViewTest, SetCanReorderItems) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, DisableCanReorderItems) {
+TEST_F(ListViewTest, DisableCanReorderItems)
+{
     ListView* lv = new ListView(window);
     lv->setCanReorderItems(true);
     lv->setCanReorderItems(false);
     EXPECT_FALSE(lv->canReorderItems());
 }
 
-TEST_F(ListViewTest, CanReorderItemsSignalNotDuplicate) {
+TEST_F(ListViewTest, CanReorderItemsSignalNotDuplicate)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::canReorderItemsChanged);
     lv->setCanReorderItems(true);
@@ -1474,7 +1562,8 @@ TEST_F(ListViewTest, CanReorderItemsSignalNotDuplicate) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, ReorderMoveRowInModel) {
+TEST_F(ListViewTest, ReorderMoveRowInModel)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 250);
@@ -1494,12 +1583,14 @@ TEST_F(ListViewTest, ReorderMoveRowInModel) {
 
 // ── Section tests ─────────────────────────────────────────────────────────────
 
-TEST_F(ListViewTest, DefaultSectionEnabled) {
+TEST_F(ListViewTest, DefaultSectionEnabled)
+{
     ListView* lv = new ListView(window);
     EXPECT_FALSE(lv->sectionEnabled());
 }
 
-TEST_F(ListViewTest, SetSectionEnabled) {
+TEST_F(ListViewTest, SetSectionEnabled)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::sectionEnabledChanged);
     lv->setSectionEnabled(true);
@@ -1507,7 +1598,8 @@ TEST_F(ListViewTest, SetSectionEnabled) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, SectionEnabledSignalNotDuplicate) {
+TEST_F(ListViewTest, SectionEnabledSignalNotDuplicate)
+{
     ListView* lv = new ListView(window);
     QSignalSpy spy(lv, &ListView::sectionEnabledChanged);
     lv->setSectionEnabled(true);
@@ -1515,7 +1607,8 @@ TEST_F(ListViewTest, SectionEnabledSignalNotDuplicate) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(ListViewTest, SetSectionKeyFunction) {
+TEST_F(ListViewTest, SetSectionKeyFunction)
+{
     window->setAttribute(Qt::WA_DontShowOnScreen, true);
     ListView* lv = new ListView(window);
     lv->setGeometry(10, 10, 300, 300);
@@ -1546,12 +1639,14 @@ public:
     int exposedVerticalOffset() const { return verticalOffset(); }
 };
 
-ListView* makeScrollableListView(QWidget* parent, int rowCount = 100) {
+ListView* makeScrollableListView(QWidget* parent, int rowCount = 100)
+{
     auto* lv = new ListView(parent);
     lv->setGeometry(10, 10, 300, 200);
     QStringList items;
     items.reserve(rowCount);
-    for (int i = 0; i < rowCount; ++i) items << QStringLiteral("Item %1").arg(i);
+    for (int i = 0; i < rowCount; ++i)
+        items << QStringLiteral("Item %1").arg(i);
     attachStringListModel(lv, items);
     lv->show();
     QTest::qWait(50);
@@ -1561,12 +1656,14 @@ ListView* makeScrollableListView(QWidget* parent, int rowCount = 100) {
     return lv;
 }
 
-InspectableListView* makeInspectableScrollableListView(QWidget* parent, int rowCount = 100) {
+InspectableListView* makeInspectableScrollableListView(QWidget* parent, int rowCount = 100)
+{
     auto* lv = new InspectableListView(parent);
     lv->setGeometry(10, 10, 300, 200);
     QStringList items;
     items.reserve(rowCount);
-    for (int i = 0; i < rowCount; ++i) items << QStringLiteral("Item %1").arg(i);
+    for (int i = 0; i < rowCount; ++i)
+        items << QStringLiteral("Item %1").arg(i);
     attachStringListModel(lv, items);
     lv->show();
     QTest::qWait(50);
@@ -1575,7 +1672,8 @@ InspectableListView* makeInspectableScrollableListView(QWidget* parent, int rowC
     return lv;
 }
 
-ListView* makeHorizontalScrollableListView(QWidget* parent, int rowCount = 40) {
+ListView* makeHorizontalScrollableListView(QWidget* parent, int rowCount = 40)
+{
     auto* lv = new ListView(parent);
     lv->setGeometry(10, 10, 180, 100);
     lv->setFlow(QListView::LeftToRight);
@@ -1594,26 +1692,29 @@ ListView* makeHorizontalScrollableListView(QWidget* parent, int rowCount = 40) {
     return lv;
 }
 
-void scrollToBottom(ListView* lv) {
+void scrollToBottom(ListView* lv)
+{
     lv->verticalScrollBar()->setValue(lv->verticalScrollBar()->maximum());
     QTest::qWait(10);
 }
 
-void scrollToTop(ListView* lv) {
+void scrollToTop(ListView* lv)
+{
     lv->verticalScrollBar()->setValue(0);
     QTest::qWait(10);
 }
 
 QWheelEvent makeWheelEvent(QWidget* target, QPoint pixelDelta, QPoint angleDelta,
-                           Qt::ScrollPhase phase) {
+                           Qt::ScrollPhase phase)
+{
     const QPointF pos = target->rect().center();
     const QPointF globalPos = target->mapToGlobal(pos.toPoint());
-    return QWheelEvent(pos, globalPos, pixelDelta, angleDelta,
-                       Qt::NoButton, Qt::NoModifier, phase, false);
+    return QWheelEvent(pos, globalPos, pixelDelta, angleDelta, Qt::NoButton, Qt::NoModifier, phase,
+                       false);
 }
 
-void sendWheel(QWidget* target, QPoint pixelDelta, QPoint angleDelta,
-               Qt::ScrollPhase phase) {
+void sendWheel(QWidget* target, QPoint pixelDelta, QPoint angleDelta, Qt::ScrollPhase phase)
+{
     QWheelEvent ev = makeWheelEvent(target, pixelDelta, angleDelta, phase);
     QApplication::sendEvent(target, &ev);
 }
@@ -1621,7 +1722,8 @@ void sendWheel(QWidget* target, QPoint pixelDelta, QPoint angleDelta,
 } // namespace
 
 // 5.4 鼠标滚轮单次离散事件 → 正常滚动
-TEST_F(ListViewTest, MouseWheelDiscreteScroll) {
+TEST_F(ListViewTest, MouseWheelDiscreteScroll)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1638,7 +1740,8 @@ TEST_F(ListViewTest, MouseWheelDiscreteScroll) {
         << "A standard mouse wheel notch should move by a usable pixel step";
 }
 
-TEST_F(ListViewTest, MouseWheelHalfTickStillScrolls) {
+TEST_F(ListViewTest, MouseWheelHalfTickStillScrolls)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1650,10 +1753,11 @@ TEST_F(ListViewTest, MouseWheelHalfTickStillScrolls) {
 
     EXPECT_GT(lv->verticalScrollBar()->value(), before)
         << "High-resolution Windows wheel/touchpad fallback ticks should not "
-         "feel inert";
+           "feel inert";
 }
 
-TEST_F(ListViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
+TEST_F(ListViewTest, ScrollChainingPropertyControlsBoundaryWheel)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1669,7 +1773,8 @@ TEST_F(ListViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
     lv->setScrollChainingEnabled(true);
     EXPECT_EQ(spy.count(), 1);
 
-    QWheelEvent chainedWheel = makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
+    QWheelEvent chainedWheel =
+        makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
     chainedWheel.setAccepted(false);
     QApplication::sendEvent(lv->viewport(), &chainedWheel);
     QTest::qWait(20);
@@ -1677,18 +1782,21 @@ TEST_F(ListViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
     EXPECT_EQ(lv->verticalScrollBar()->value(), maxValue);
 
     lv->setScrollChainingEnabled(false);
-    QWheelEvent containedWheel = makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
+    QWheelEvent containedWheel =
+        makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
     containedWheel.setAccepted(false);
     QApplication::sendEvent(lv->viewport(), &containedWheel);
     QTest::qWait(20);
     EXPECT_TRUE(containedWheel.isAccepted());
 }
 
-TEST_F(ListViewTest, WheelPassesThroughWhenContentFits) {
+TEST_F(ListViewTest, WheelPassesThroughWhenContentFits)
+{
     auto* lv = makeScrollableListView(window, 2);
     ASSERT_EQ(lv->verticalScrollBar()->maximum(), lv->verticalScrollBar()->minimum());
 
-    QWheelEvent wheel = makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
+    QWheelEvent wheel =
+        makeWheelEvent(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
     wheel.setAccepted(false);
     QApplication::sendEvent(lv->viewport(), &wheel);
     QTest::qWait(20);
@@ -1697,7 +1805,8 @@ TEST_F(ListViewTest, WheelPassesThroughWhenContentFits) {
 }
 
 // 5.3 Windows 触控板 cluster 高频序列 → 滚动平滑
-TEST_F(ListViewTest, WindowsTouchpadClusterScroll) {
+TEST_F(ListViewTest, WindowsTouchpadClusterScroll)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1715,15 +1824,15 @@ TEST_F(ListViewTest, WindowsTouchpadClusterScroll) {
 }
 
 // 5.2 Mac RDP → Windows 单次轻拨：5 个小角度事件，30ms 间隔 → 边界不反复 flap
-TEST_F(ListViewTest, RdpHighFreqNoBounceFlap) {
+TEST_F(ListViewTest, RdpHighFreqNoBounceFlap)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
     }
     scrollToBottom(lv);
     const int sbVal = lv->verticalScrollBar()->value();
-    EXPECT_EQ(sbVal, lv->verticalScrollBar()->maximum())
-        << "Pre-condition: scrolled to bottom";
+    EXPECT_EQ(sbVal, lv->verticalScrollBar()->maximum()) << "Pre-condition: scrolled to bottom";
 
     // 模拟 Mac RDP 单次轻拨：5 个小 angleDelta（±60，scrollPx ≈ 60/120*20 = 10），30ms 间隔
     // 同向越界尾部可触发一次短回弹，但不能反复叠加或污染滚动条。
@@ -1738,7 +1847,8 @@ TEST_F(ListViewTest, RdpHighFreqNoBounceFlap) {
         << "Scrollbar should stay pinned at boundary";
 }
 
-TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailStartsBounceAndSettles) {
+TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailStartsBounceAndSettles)
+{
     auto* lv = makeInspectableScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1751,7 +1861,7 @@ TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailStartsBounceAndSettles) {
 
     EXPECT_GT(lv->exposedVerticalOffset(), beforeOffset)
         << "Windows NoPhaseDiscrete boundary input should still show a bounded "
-         "bounce";
+           "bounce";
 
     QTest::qWait(500);
 
@@ -1759,7 +1869,8 @@ TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailStartsBounceAndSettles) {
         << "The one-shot boundary bounce should settle back to the native offset";
 }
 
-TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailDoesNotExtendActiveBounce) {
+TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailDoesNotExtendActiveBounce)
+{
     auto* lv = makeInspectableScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1769,9 +1880,8 @@ TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailDoesNotExtendActiveBounce) {
 
     sendWheel(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
     const int firstDelta = lv->exposedVerticalOffset() - beforeOffset;
-    ASSERT_GT(firstDelta, 0)
-        << "Pre-condition: boundary input should create "
-                              "visible overscroll feedback";
+    ASSERT_GT(firstDelta, 0) << "Pre-condition: boundary input should create "
+                                "visible overscroll feedback";
 
     for (int i = 0; i < 4; ++i) {
         sendWheel(lv->viewport(), QPoint(0, 0), QPoint(0, -120), Qt::NoScrollPhase);
@@ -1779,17 +1889,17 @@ TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailDoesNotExtendActiveBounce) {
     }
 
     const int tailDelta = lv->exposedVerticalOffset() - beforeOffset;
-    EXPECT_LE(tailDelta, firstDelta)
-        << "Same-direction boundary tails should "
-                                      "not extend or restart the active bounce";
+    EXPECT_LE(tailDelta, firstDelta) << "Same-direction boundary tails should "
+                                        "not extend or restart the active bounce";
 
     QTest::qWait(400);
     EXPECT_EQ(lv->exposedVerticalOffset(), beforeOffset)
         << "The original bounce should settle without being prolonged by tail "
-         "events";
+           "events";
 }
 
-TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailAllowsReverseRecovery) {
+TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailAllowsReverseRecovery)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1804,17 +1914,18 @@ TEST_F(ListViewTest, NoPhaseDiscreteBoundaryTailAllowsReverseRecovery) {
 
     EXPECT_EQ(lv->verticalScrollBar()->value(), maxValue)
         << "Same-direction NoPhaseDiscrete boundary tails should be consumed at "
-         "the edge";
+           "the edge";
 
     sendWheel(lv->viewport(), QPoint(0, 0), QPoint(0, 120), Qt::NoScrollPhase);
     QTest::qWait(20);
 
     EXPECT_LT(lv->verticalScrollBar()->value(), maxValue)
         << "Reverse NoPhaseDiscrete input should immediately scroll back into "
-         "content";
+           "content";
 }
 
-TEST_F(ListViewTest, RdpClusterReachingBoundaryRecoversOnReverseTick) {
+TEST_F(ListViewTest, RdpClusterReachingBoundaryRecoversOnReverseTick)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1829,18 +1940,19 @@ TEST_F(ListViewTest, RdpClusterReachingBoundaryRecoversOnReverseTick) {
     }
     EXPECT_EQ(lv->verticalScrollBar()->value(), maxValue)
         << "High-frequency NoPhaseDiscrete cluster should pin at the bottom "
-         "boundary";
+           "boundary";
 
     sendWheel(lv->viewport(), QPoint(0, 0), QPoint(0, 120), Qt::NoScrollPhase);
     QTest::qWait(20);
 
     EXPECT_LT(lv->verticalScrollBar()->value(), maxValue)
         << "A reverse tick after the boundary cluster should not be swallowed by "
-         "stale state";
+           "stale state";
 }
 
 // 5.5 bounce 期间 NoPhase 事件被吞
-TEST_F(ListViewTest, BounceConsumesNoPhaseEvents) {
+TEST_F(ListViewTest, BounceConsumesNoPhaseEvents)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1863,7 +1975,8 @@ TEST_F(ListViewTest, BounceConsumesNoPhaseEvents) {
 }
 
 // 5.7 macOS 触控板（PhaseBased）边界 overscroll 不回归
-TEST_F(ListViewTest, MacOsTrackpadOverscrollNoRegression) {
+TEST_F(ListViewTest, MacOsTrackpadOverscrollNoRegression)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1883,7 +1996,8 @@ TEST_F(ListViewTest, MacOsTrackpadOverscrollNoRegression) {
         << "After bounce-back, scrollbar should be at boundary";
 }
 
-TEST_F(ListViewTest, PhaseBasedOverscrollSettlesWhenBackendOmitsScrollEnd) {
+TEST_F(ListViewTest, PhaseBasedOverscrollSettlesWhenBackendOmitsScrollEnd)
+{
     auto* lv = makeInspectableScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1900,7 +2014,8 @@ TEST_F(ListViewTest, PhaseBasedOverscrollSettlesWhenBackendOmitsScrollEnd) {
         << "Missing ScrollEnd must not leave a browser-style gesture stretched";
 }
 
-TEST_F(ListViewTest, NoPhasePixelOverscrollSettlesAfterInputBecomesIdle) {
+TEST_F(ListViewTest, NoPhasePixelOverscrollSettlesAfterInputBecomesIdle)
+{
     auto* lv = makeInspectableScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1918,7 +2033,8 @@ TEST_F(ListViewTest, NoPhasePixelOverscrollSettlesAfterInputBecomesIdle) {
 }
 
 // 5.1 三类事件分类：NoScrollPhase + pixelDelta != 0 走 NoPhasePixel 路径
-TEST_F(ListViewTest, NoPhasePixelDirectScroll) {
+TEST_F(ListViewTest, NoPhasePixelDirectScroll)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1934,7 +2050,8 @@ TEST_F(ListViewTest, NoPhasePixelDirectScroll) {
 }
 
 // 5.6 PhaseBased 事件可打断 bounce
-TEST_F(ListViewTest, BounceInterruptedByPhaseBased) {
+TEST_F(ListViewTest, BounceInterruptedByPhaseBased)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1954,7 +2071,8 @@ TEST_F(ListViewTest, BounceInterruptedByPhaseBased) {
     SUCCEED() << "PhaseBased event during bounce did not crash";
 }
 
-TEST_F(ListViewTest, HorizontalNoPhaseDiscreteUsesDominantAxis) {
+TEST_F(ListViewTest, HorizontalNoPhaseDiscreteUsesDominantAxis)
+{
     auto* lv = makeHorizontalScrollableListView(window);
     if (lv->horizontalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not horizontally scrollable in this environment";
@@ -1966,10 +2084,11 @@ TEST_F(ListViewTest, HorizontalNoPhaseDiscreteUsesDominantAxis) {
 
     EXPECT_GT(lv->horizontalScrollBar()->value(), before)
         << "LeftToRight ListView should scroll horizontally from dominant Y-axis "
-         "NoPhaseDiscrete input";
+           "NoPhaseDiscrete input";
 }
 
-TEST_F(ListViewTest, KeyboardSelectionWorksAfterNoPhaseDiscreteWheel) {
+TEST_F(ListViewTest, KeyboardSelectionWorksAfterNoPhaseDiscreteWheel)
+{
     auto* lv = makeScrollableListView(window);
     if (lv->verticalScrollBar()->maximum() <= 0) {
         GTEST_SKIP() << "Layout not scrollable in this environment";
@@ -1987,12 +2106,13 @@ TEST_F(ListViewTest, KeyboardSelectionWorksAfterNoPhaseDiscreteWheel) {
 
     EXPECT_EQ(lv->selectedIndex(), 1)
         << "Keyboard navigation and selection should remain governed by the "
-         "selection model";
+           "selection model";
 }
 
 // ── 可视化测试（业务组装与上面一致）───────────────────────────────────────────
 
-TEST_F(ListViewTest, VisualCheck) {
+TEST_F(ListViewTest, VisualCheck)
+{
     if (qEnvironmentVariableIsSet("SKIP_VISUAL_TEST")) {
         GTEST_SKIP() << "Set SKIP_VISUAL_TEST=1 to skip visual tests";
     }
@@ -2012,8 +2132,8 @@ TEST_F(ListViewTest, VisualCheck) {
     auto* fluentVBar = new fluent::scrolling::ScrollBar(Qt::Vertical, scrollArea);
     fluentVBar->setObjectName("fluentScrollAreaVBar");
     auto* nativeVBar = scrollArea->verticalScrollBar();
-    QObject::connect(nativeVBar,  &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
-    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar,  &QScrollBar::setValue);
+    QObject::connect(nativeVBar, &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
+    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar, &QScrollBar::setValue);
 
     // 同步 range / pageStep 并定位
     auto syncFluentBar = [scrollArea, fluentVBar, nativeVBar]() {
@@ -2021,7 +2141,8 @@ TEST_F(ListViewTest, VisualCheck) {
         fluentVBar->setPageStep(nativeVBar->pageStep());
         const bool need = nativeVBar->maximum() > nativeVBar->minimum();
         fluentVBar->setVisible(need);
-        if (!need) return;
+        if (!need)
+            return;
         const QRect r = scrollArea->rect();
         const int x = r.right() - fluentVBar->thickness() + 1;
         fluentVBar->setGeometry(x, r.top() + 2, fluentVBar->thickness(), r.height() - 4);
@@ -2040,18 +2161,18 @@ TEST_F(ListViewTest, VisualCheck) {
     ListView* lv1 = new ListView(content);
     lv1->setHeaderText("Fruits (Single Selection)");
     lv1->setBorderVisible(true);
-    attachStringListModel(lv1, {"Apricot", "Banana", "Cherry", "Date", "Elderberry",
-                                 "Fig", "Grape", "Honeydew"});
+    attachStringListModel(
+        lv1, {"Apricot", "Banana", "Cherry", "Date", "Elderberry", "Fig", "Grape", "Honeydew"});
     lv1->setSelectedIndex(2);
     lv1->setFixedHeight(250);
-    lv1->anchors()->top   = {content, Edge::Top,  20};
-    lv1->anchors()->left  = {content, Edge::Left, 20};
+    lv1->anchors()->top = {content, Edge::Top, 20};
+    lv1->anchors()->left = {content, Edge::Left, 20};
     lv1->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv1);
 
     // --- ListView 2: 多选模式，无 border ---
     Label* header2 = new Label("Multiple Selection (no border):", content);
-    header2->anchors()->top  = {lv1, Edge::Bottom, 16};
+    header2->anchors()->top = {lv1, Edge::Bottom, 16};
     header2->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header2);
 
@@ -2060,14 +2181,14 @@ TEST_F(ListViewTest, VisualCheck) {
     lv2->setBorderVisible(false);
     attachStringListModel(lv2, {"Item A", "Item B", "Item C", "Item D"});
     lv2->setFixedHeight(160);
-    lv2->anchors()->top   = {header2, Edge::Bottom, 8};
-    lv2->anchors()->left  = {content, Edge::Left, 20};
+    lv2->anchors()->top = {header2, Edge::Bottom, 8};
+    lv2->anchors()->left = {content, Edge::Left, 20};
     lv2->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv2);
 
     // --- ListView 3: 空列表，显示 placeholder ---
     Label* header3 = new Label("Empty list with placeholder:", content);
-    header3->anchors()->top  = {lv2, Edge::Bottom, 16};
+    header3->anchors()->top = {lv2, Edge::Bottom, 16};
     header3->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header3);
 
@@ -2077,14 +2198,14 @@ TEST_F(ListViewTest, VisualCheck) {
     lv3->setBorderVisible(true);
     attachStringListModel(lv3);
     lv3->setFixedHeight(100);
-    lv3->anchors()->top   = {header3, Edge::Bottom, 8};
-    lv3->anchors()->left  = {content, Edge::Left, 20};
+    lv3->anchors()->top = {header3, Edge::Bottom, 8};
+    lv3->anchors()->left = {content, Edge::Left, 20};
     lv3->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv3);
 
     // --- ListView 4: 水平方向列表 ---
     Label* header4 = new Label("Horizontal Flow (LeftToRight):", content);
-    header4->anchors()->top  = {lv3, Edge::Bottom, 16};
+    header4->anchors()->top = {lv3, Edge::Bottom, 16};
     header4->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header4);
 
@@ -2092,19 +2213,18 @@ TEST_F(ListViewTest, VisualCheck) {
     lv4->setFlow(QListView::LeftToRight);
     lv4->setBorderVisible(true);
     lv4->setWrapping(false);
-    attachStringListModel(lv4, {"Alpha", "Bravo", "Charlie", "Delta", "Echo",
-                                 "Foxtrot", "Golf", "Hotel", "India", "Juliet",
-                                 "Kilo", "Lima", "Mike", "November"});
+    attachStringListModel(lv4, {"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf",
+                                "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November"});
     lv4->setSelectedIndex(3);
     lv4->setFixedHeight(100);
-    lv4->anchors()->top   = {header4, Edge::Bottom, 8};
-    lv4->anchors()->left  = {content, Edge::Left, 20};
+    lv4->anchors()->top = {header4, Edge::Bottom, 8};
+    lv4->anchors()->left = {content, Edge::Left, 20};
     lv4->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv4);
 
     // --- ListView 5: 水平方向 + 多选 ---
     Label* header5 = new Label("Horizontal Multiple Selection:", content);
-    header5->anchors()->top  = {lv4, Edge::Bottom, 16};
+    header5->anchors()->top = {lv4, Edge::Bottom, 16};
     header5->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header5);
 
@@ -2113,17 +2233,17 @@ TEST_F(ListViewTest, VisualCheck) {
     lv5->setSelectionMode(SelectionMode::Multiple);
     lv5->setBorderVisible(true);
     lv5->setWrapping(false);
-    attachStringListModel(lv5, {"Red", "Orange", "Yellow", "Green", "Blue",
-                                 "Indigo", "Violet", "Pink", "Cyan", "Magenta"});
+    attachStringListModel(lv5, {"Red", "Orange", "Yellow", "Green", "Blue", "Indigo", "Violet",
+                                "Pink", "Cyan", "Magenta"});
     lv5->setFixedHeight(100);
-    lv5->anchors()->top   = {header5, Edge::Bottom, 8};
-    lv5->anchors()->left  = {content, Edge::Left, 20};
+    lv5->anchors()->top = {header5, Edge::Bottom, 8};
+    lv5->anchors()->left = {content, Edge::Left, 20};
     lv5->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv5);
 
     // --- ListView 6: Custom Header + Footer widgets ---
     Label* header6 = new Label("Custom Header + Footer Widgets:", content);
-    header6->anchors()->top  = {lv5, Edge::Bottom, 16};
+    header6->anchors()->top = {lv5, Edge::Bottom, 16};
     header6->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header6);
 
@@ -2152,8 +2272,8 @@ TEST_F(ListViewTest, VisualCheck) {
             QPixmap pm;
             pm.loadFromData(reply->readAll());
             if (!pm.isNull()) {
-                footerLabel->setPixmap(pm.scaledToHeight(
-                    footerLabel->height(), Qt::SmoothTransformation));
+                footerLabel->setPixmap(
+                    pm.scaledToHeight(footerLabel->height(), Qt::SmoothTransformation));
             }
         } else {
             footerLabel->setText("Image unavailable");
@@ -2164,14 +2284,14 @@ TEST_F(ListViewTest, VisualCheck) {
 
     attachStringListModel(lv6, {"Alice", "Bob", "Charlie", "Diana"});
     lv6->setFixedHeight(280);
-    lv6->anchors()->top   = {header6, Edge::Bottom, 8};
-    lv6->anchors()->left  = {content, Edge::Left, 20};
+    lv6->anchors()->top = {header6, Edge::Bottom, 8};
+    lv6->anchors()->left = {content, Edge::Left, 20};
     lv6->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv6);
 
     // --- ListView 7: Drag reorder ---
     Label* header7 = new Label("Drag to Reorder:", content);
-    header7->anchors()->top  = {lv6, Edge::Bottom, 16};
+    header7->anchors()->top = {lv6, Edge::Bottom, 16};
     header7->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header7);
 
@@ -2181,14 +2301,14 @@ TEST_F(ListViewTest, VisualCheck) {
     lv7->setCanReorderItems(true);
     attachStringListModel(lv7, {"High", "Medium", "Low", "None", "Critical"});
     lv7->setFixedHeight(200);
-    lv7->anchors()->top   = {header7, Edge::Bottom, 8};
-    lv7->anchors()->left  = {content, Edge::Left, 20};
+    lv7->anchors()->top = {header7, Edge::Bottom, 8};
+    lv7->anchors()->left = {content, Edge::Left, 20};
     lv7->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv7);
 
     // --- ListView 8: Section grouping ---
     Label* header8 = new Label("Section Grouping:", content);
-    header8->anchors()->top  = {lv7, Edge::Bottom, 16};
+    header8->anchors()->top = {lv7, Edge::Bottom, 16};
     header8->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header8);
 
@@ -2196,35 +2316,35 @@ TEST_F(ListViewTest, VisualCheck) {
     lv8->setHeaderText("Grouped Items");
     lv8->setBorderVisible(true);
     lv8->setSectionEnabled(true);
-    attachStringListModel(lv8, {"Apple", "Avocado", "Banana", "Blueberry",
-                                 "Cherry", "Cranberry", "Date", "Dragonfruit"});
+    attachStringListModel(lv8, {"Apple", "Avocado", "Banana", "Blueberry", "Cherry", "Cranberry",
+                                "Date", "Dragonfruit"});
     lv8->setSectionKeyFunction([lv8](int row) -> QString {
         auto idx = lv8->model()->index(row, 0);
         return idx.data().toString().left(1);
     });
     lv8->setFixedHeight(280);
-    lv8->anchors()->top   = {header8, Edge::Bottom, 8};
-    lv8->anchors()->left  = {content, Edge::Left, 20};
+    lv8->anchors()->top = {header8, Edge::Bottom, 8};
+    lv8->anchors()->left = {content, Edge::Left, 20};
     lv8->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv8);
 
     // --- ListView 9: Vertical indicator motion ---
     Label* header9 = new Label("Vertical Indicator Motion:", content);
-    header9->anchors()->top  = {lv8, Edge::Bottom, 16};
+    header9->anchors()->top = {lv8, Edge::Bottom, 16};
     header9->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header9);
 
     Button* verticalUpBtn = new Button("Previous", content);
     verticalUpBtn->setIconGlyph(Typography::Icons::ChevronUp);
     verticalUpBtn->setFixedSize(120, 32);
-    verticalUpBtn->anchors()->top  = {header9, Edge::Bottom, 8};
+    verticalUpBtn->anchors()->top = {header9, Edge::Bottom, 8};
     verticalUpBtn->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(verticalUpBtn);
 
     Button* verticalDownBtn = new Button("Next", content);
     verticalDownBtn->setIconGlyph(Typography::Icons::ChevronDown);
     verticalDownBtn->setFixedSize(120, 32);
-    verticalDownBtn->anchors()->top  = {header9, Edge::Bottom, 8};
+    verticalDownBtn->anchors()->top = {header9, Edge::Bottom, 8};
     verticalDownBtn->anchors()->left = {verticalUpBtn, Edge::Right, 8};
     innerLayout->addWidget(verticalDownBtn);
 
@@ -2234,8 +2354,8 @@ TEST_F(ListViewTest, VisualCheck) {
     attachStringListModel(lv9, {"Home", "Dashboard", "Messages", "Calendar", "Files", "Settings"});
     lv9->setSelectedIndex(2);
     lv9->setFixedHeight(220);
-    lv9->anchors()->top   = {verticalUpBtn, Edge::Bottom, 8};
-    lv9->anchors()->left  = {content, Edge::Left, 20};
+    lv9->anchors()->top = {verticalUpBtn, Edge::Bottom, 8};
+    lv9->anchors()->left = {content, Edge::Left, 20};
     lv9->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv9);
 
@@ -2250,21 +2370,21 @@ TEST_F(ListViewTest, VisualCheck) {
 
     // --- ListView 10: Horizontal indicator motion ---
     Label* header10 = new Label("Horizontal Indicator Motion:", content);
-    header10->anchors()->top  = {lv9, Edge::Bottom, 16};
+    header10->anchors()->top = {lv9, Edge::Bottom, 16};
     header10->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header10);
 
     Button* horizontalLeftBtn = new Button("Previous", content);
     horizontalLeftBtn->setIconGlyph(Typography::Icons::ChevronLeft);
     horizontalLeftBtn->setFixedSize(120, 32);
-    horizontalLeftBtn->anchors()->top  = {header10, Edge::Bottom, 8};
+    horizontalLeftBtn->anchors()->top = {header10, Edge::Bottom, 8};
     horizontalLeftBtn->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(horizontalLeftBtn);
 
     Button* horizontalRightBtn = new Button("Next", content);
     horizontalRightBtn->setIconGlyph(Typography::Icons::ChevronRight);
     horizontalRightBtn->setFixedSize(120, 32);
-    horizontalRightBtn->anchors()->top  = {header10, Edge::Bottom, 8};
+    horizontalRightBtn->anchors()->top = {header10, Edge::Bottom, 8};
     horizontalRightBtn->anchors()->left = {horizontalLeftBtn, Edge::Right, 8};
     innerLayout->addWidget(horizontalRightBtn);
 
@@ -2272,11 +2392,12 @@ TEST_F(ListViewTest, VisualCheck) {
     lv10->setFlow(QListView::LeftToRight);
     lv10->setWrapping(false);
     lv10->setBorderVisible(true);
-    attachStringListModel(lv10, {"Overview", "Activity", "Files", "Members", "Settings", "History", "Insights"});
+    attachStringListModel(
+        lv10, {"Overview", "Activity", "Files", "Members", "Settings", "History", "Insights"});
     lv10->setSelectedIndex(2);
     lv10->setFixedHeight(100);
-    lv10->anchors()->top   = {horizontalLeftBtn, Edge::Bottom, 8};
-    lv10->anchors()->left  = {content, Edge::Left, 20};
+    lv10->anchors()->top = {horizontalLeftBtn, Edge::Bottom, 8};
+    lv10->anchors()->left = {content, Edge::Left, 20};
     lv10->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(lv10);
 
@@ -2293,17 +2414,19 @@ TEST_F(ListViewTest, VisualCheck) {
     Button* themeBtn = new Button("Switch Theme", content);
     themeBtn->setFluentStyle(Button::Accent);
     themeBtn->setFixedSize(120, 32);
-    themeBtn->anchors()->top  = {lv10, Edge::Bottom, 16};
+    themeBtn->anchors()->top = {lv10, Edge::Bottom, 16};
     themeBtn->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(themeBtn);
 
     // content 的最小高度根据最底部控件计算
-    content->setMinimumHeight(250 + 160 + 100 + 100 + 100 + 200 + 200 + 280 + 220 + 100 + 16*10 + 8*12 + 20*2 + 32 + 180);
+    content->setMinimumHeight(250 + 160 + 100 + 100 + 100 + 200 + 200 + 280 + 220 + 100 + 16 * 10 +
+                              8 * 12 + 20 * 2 + 32 + 180);
 
     QObject::connect(themeBtn, &Button::clicked, [scrollArea, content]() {
-        fluent::FluentElement::setTheme(
-            fluent::FluentElement::currentTheme() == fluent::FluentElement::Light
-                ? fluent::FluentElement::Dark : fluent::FluentElement::Light);
+        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() ==
+                                                fluent::FluentElement::Light
+                                            ? fluent::FluentElement::Dark
+                                            : fluent::FluentElement::Light);
         content->onThemeUpdated();
         scrollArea->setStyleSheet(content->styleSheet());
     });

--- a/tests/components/collections/TestTreeView.cpp
+++ b/tests/components/collections/TestTreeView.cpp
@@ -1163,14 +1163,17 @@ TEST_F(TreeViewTest, ItemClickedSignalEmitted) {
 
     showOffscreen(window);
 
-    QSignalSpy spy(tv, &TreeView::itemClicked);
+    QSignalSpy inheritedClickSpy(tv, &QAbstractItemView::clicked);
+    QSignalSpy itemClickSpy(tv, &TreeView::itemClicked);
 
     QModelIndex idx = model->index(0, 0);
     QRect rect = tv->visualRect(idx);
     QTest::mouseClick(tv->viewport(), Qt::LeftButton, Qt::NoModifier, rect.center());
 
-    EXPECT_GE(spy.count(), 1);
-    QModelIndex clickedIdx = spy.at(0).at(0).value<QModelIndex>();
+    ASSERT_EQ(inheritedClickSpy.count(), 1);
+    EXPECT_EQ(inheritedClickSpy.at(0).at(0).value<QModelIndex>(), idx);
+    ASSERT_EQ(itemClickSpy.count(), 1);
+    QModelIndex clickedIdx = itemClickSpy.at(0).at(0).value<QModelIndex>();
     EXPECT_EQ(clickedIdx, idx);
 }
 
@@ -1181,15 +1184,18 @@ TEST_F(TreeViewTest, ItemPressedSignalEmittedOnMousePress) {
 
     showOffscreen(window);
 
-    QSignalSpy spy(tv, &TreeView::itemPressed);
+    QSignalSpy inheritedPressSpy(tv, &QAbstractItemView::pressed);
+    QSignalSpy itemPressSpy(tv, &TreeView::itemPressed);
 
     const QModelIndex idx = model->index(0, 0);
     const QRect rect = tv->visualRect(idx);
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, rect.center());
     QApplication::processEvents();
 
-    EXPECT_GE(spy.count(), 1);
-    const QModelIndex pressedIdx = spy.at(0).at(0).value<QModelIndex>();
+    ASSERT_EQ(inheritedPressSpy.count(), 1);
+    EXPECT_EQ(inheritedPressSpy.at(0).at(0).value<QModelIndex>(), idx);
+    ASSERT_EQ(itemPressSpy.count(), 1);
+    const QModelIndex pressedIdx = itemPressSpy.at(0).at(0).value<QModelIndex>();
     EXPECT_EQ(pressedIdx, idx);
     QTest::mouseRelease(tv->viewport(), Qt::LeftButton, Qt::NoModifier, rect.center());
 }

--- a/tests/components/collections/TestTreeView.cpp
+++ b/tests/components/collections/TestTreeView.cpp
@@ -39,7 +39,8 @@ class PaintRegionTreeView : public TreeView {
 public:
     using TreeView::TreeView;
 
-    void resetAnimatedPaintObservations() {
+    void resetAnimatedPaintObservations()
+    {
         observedAnimatedPaint = false;
         observedFullViewportAnimatedPaint = false;
     }
@@ -48,32 +49,35 @@ public:
     bool observedFullViewportAnimatedPaint = false;
 
 protected:
-    void paintEvent(QPaintEvent* event) override {
+    void paintEvent(QPaintEvent* event) override
+    {
         const qreal progress = indicatorMotionProgress();
         if (progress > 0.0 && progress < 1.0) {
             observedAnimatedPaint = true;
             observedFullViewportAnimatedPaint =
-                observedFullViewportAnimatedPaint
-                || event->region().contains(viewport()->rect());
+                observedFullViewportAnimatedPaint || event->region().contains(viewport()->rect());
         }
         TreeView::paintEvent(event);
     }
 };
 
-int defaultTreeRowHeight() {
+int defaultTreeRowHeight()
+{
     return Spacing::ControlHeight::Standard + Spacing::Gap::Tight;
 }
 
 /** 业务组装：为 TreeView 挂上 Fluent 行代理 */
-void attachFluentDelegate(TreeView* tv, int rowHeight = defaultTreeRowHeight()) {
+void attachFluentDelegate(TreeView* tv, int rowHeight = defaultTreeRowHeight())
+{
     tv->setItemDelegate(new treeview_test::FluentTreeItemDelegate(
         static_cast<fluent::FluentElement*>(tv), rowHeight, tv, tv));
 }
 
 /** 挂上带 CheckBox 可见的代理 */
-treeview_test::FluentTreeItemDelegate* attachCheckableDelegate(TreeView* tv) {
-    auto* d = new treeview_test::FluentTreeItemDelegate(
-        static_cast<fluent::FluentElement*>(tv), defaultTreeRowHeight(), tv, tv);
+treeview_test::FluentTreeItemDelegate* attachCheckableDelegate(TreeView* tv)
+{
+    auto* d = new treeview_test::FluentTreeItemDelegate(static_cast<fluent::FluentElement*>(tv),
+                                                        defaultTreeRowHeight(), tv, tv);
     d->setCheckBoxVisible(true);
     tv->setItemDelegate(d);
     return d;
@@ -90,7 +94,8 @@ treeview_test::FluentTreeItemDelegate* attachCheckableDelegate(TreeView* tv) {
  *         └─ Paint Color Scheme
  *   Pictures
  */
-QStandardItemModel* createSampleTreeModel(QObject* parent = nullptr) {
+QStandardItemModel* createSampleTreeModel(QObject* parent = nullptr)
+{
     auto* model = new QStandardItemModel(parent);
 
     auto* work = new QStandardItem("Work Documents");
@@ -111,43 +116,49 @@ QStandardItemModel* createSampleTreeModel(QObject* parent = nullptr) {
 }
 
 /** 绑定 sample model + delegate */
-QStandardItemModel* attachSampleModel(TreeView* tv) {
+QStandardItemModel* attachSampleModel(TreeView* tv)
+{
     auto* model = createSampleTreeModel(tv);
     tv->setModel(model);
     attachFluentDelegate(tv);
     return model;
 }
 
-int topLevelCount(TreeView* tv) {
+int topLevelCount(TreeView* tv)
+{
     return tv->model() ? tv->model()->rowCount() : 0;
 }
 
-QString itemText(TreeView* tv, const QModelIndex& index) {
+QString itemText(TreeView* tv, const QModelIndex& index)
+{
     return index.isValid() ? index.data(Qt::DisplayRole).toString() : QString();
 }
 
 /** 离屏显示: 触发布局计算但不弹出可见窗口 */
-void showOffscreen(QWidget* w) {
+void showOffscreen(QWidget* w)
+{
     w->setAttribute(Qt::WA_DontShowOnScreen, true);
     w->show();
     QApplication::processEvents();
 }
 
-void processEvents() {
+void processEvents()
+{
     QApplication::processEvents();
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
     QApplication::processEvents();
 }
 
-bool isAccentLike(const QColor& color, const QColor& accent) {
+bool isAccentLike(const QColor& color, const QColor& accent)
+{
     constexpr int kTolerance = 42;
-    return color.alpha() > 160
-        && qAbs(color.red() - accent.red()) <= kTolerance
-        && qAbs(color.green() - accent.green()) <= kTolerance
-        && qAbs(color.blue() - accent.blue()) <= kTolerance;
+    return color.alpha() > 160 && qAbs(color.red() - accent.red()) <= kTolerance &&
+           qAbs(color.green() - accent.green()) <= kTolerance &&
+           qAbs(color.blue() - accent.blue()) <= kTolerance;
 }
 
-QImage renderWidget(QWidget* widget) {
+QImage renderWidget(QWidget* widget)
+{
     QImage image(widget->size(), QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);
     QPainter painter(&image);
@@ -156,7 +167,8 @@ QImage renderWidget(QWidget* widget) {
     return image;
 }
 
-int leftMostAccentPixelX(QWidget* widget, const QRect& rowRect, const QColor& accent) {
+int leftMostAccentPixelX(QWidget* widget, const QRect& rowRect, const QColor& accent)
+{
     const QImage image = renderWidget(widget);
     const int top = qBound(0, rowRect.top(), image.height() - 1);
     const int bottom = qBound(0, rowRect.bottom(), image.height() - 1);
@@ -169,7 +181,8 @@ int leftMostAccentPixelX(QWidget* widget, const QRect& rowRect, const QColor& ac
     return -1;
 }
 
-bool hasAccentPixelInRect(QWidget* widget, const QRect& rect, const QColor& accent) {
+bool hasAccentPixelInRect(QWidget* widget, const QRect& rect, const QColor& accent)
+{
     const QImage image = renderWidget(widget);
     const QRect bounded = rect.intersected(QRect(0, 0, image.width(), image.height()));
     for (int y = bounded.top(); y <= bounded.bottom(); ++y) {
@@ -181,7 +194,8 @@ bool hasAccentPixelInRect(QWidget* widget, const QRect& rect, const QColor& acce
     return false;
 }
 
-bool hasAccentPixelInImage(const QImage& image, const QRect& rect, const QColor& accent) {
+bool hasAccentPixelInImage(const QImage& image, const QRect& rect, const QColor& accent)
+{
     const QRect bounded = rect.intersected(QRect(0, 0, image.width(), image.height()));
     for (int y = bounded.top(); y <= bounded.bottom(); ++y) {
         for (int x = bounded.left(); x <= bounded.right(); ++x) {
@@ -195,7 +209,8 @@ bool hasAccentPixelInImage(const QImage& image, const QRect& rect, const QColor&
 /**
  * 创建一个带 CheckStateRole 的可勾选树模型 (WinUI Multi-selection 模式)
  */
-QStandardItemModel* createCheckableTreeModel(QObject* parent = nullptr) {
+QStandardItemModel* createCheckableTreeModel(QObject* parent = nullptr)
+{
     auto* model = new QStandardItemModel(parent);
 
     auto makeCheckable = [](QStandardItem* item, Qt::CheckState state) {
@@ -220,7 +235,8 @@ QStandardItemModel* createCheckableTreeModel(QObject* parent = nullptr) {
     return model;
 }
 
-void selectCheckedRows(TreeView* tv, const QModelIndex& parent = QModelIndex()) {
+void selectCheckedRows(TreeView* tv, const QModelIndex& parent = QModelIndex())
+{
     if (!tv || !tv->model() || !tv->selectionModel())
         return;
 
@@ -228,7 +244,8 @@ void selectCheckedRows(TreeView* tv, const QModelIndex& parent = QModelIndex()) 
         const QModelIndex index = tv->model()->index(row, 0, parent);
         const QVariant checkState = index.data(Qt::CheckStateRole);
         if (checkState.isValid() && static_cast<Qt::CheckState>(checkState.toInt()) == Qt::Checked)
-            tv->selectionModel()->select(index, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+            tv->selectionModel()->select(index,
+                                         QItemSelectionModel::Select | QItemSelectionModel::Rows);
         selectCheckedRows(tv, index);
     }
 }
@@ -237,7 +254,8 @@ void selectCheckedRows(TreeView* tv, const QModelIndex& parent = QModelIndex()) 
  * 创建带图标字形的树模型 (WinUI ItemTemplateSelector 模式)
  * 文件夹使用 Folder 图标，文档使用 Document 图标
  */
-QStandardItemModel* createIconTreeModel(QObject* parent = nullptr) {
+QStandardItemModel* createIconTreeModel(QObject* parent = nullptr)
+{
     auto* model = new QStandardItemModel(parent);
 
     auto makeFolder = [](const QString& text) {
@@ -272,7 +290,8 @@ QStandardItemModel* createIconTreeModel(QObject* parent = nullptr) {
 class FluentTestWindow : public QWidget, public fluent::FluentElement {
 public:
     using QWidget::QWidget;
-    void onThemeUpdated() override {
+    void onThemeUpdated() override
+    {
         const auto& c = themeColors();
         setStyleSheet(QString("background-color: %1;").arg(c.bgCanvas.name()));
     }
@@ -280,14 +299,16 @@ public:
 
 class TreeViewTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite() {
+    static void SetUpTestSuite()
+    {
         qRegisterMetaType<fluent::collections::TreeView::IndicatorVerticalDirection>(
             "fluent::collections::TreeView::IndicatorVerticalDirection");
         qRegisterMetaType<fluent::collections::TreeView::IndicatorHierarchyTransition>(
             "fluent::collections::TreeView::IndicatorHierarchyTransition");
     }
 
-    void SetUp() override {
+    void SetUp() override
+    {
         window = new FluentTestWindow();
         window->setFixedSize(500, 500);
         window->setWindowTitle("Fluent TreeView Test");
@@ -296,9 +317,7 @@ protected:
         window->onThemeUpdated();
     }
 
-    void TearDown() override {
-        delete window;
-    }
+    void TearDown() override { delete window; }
 
     FluentTestWindow* window;
     AnchorLayout* layout;
@@ -308,13 +327,15 @@ protected:
 // Model & Data
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, EmptyTreeView) {
+TEST_F(TreeViewTest, EmptyTreeView)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_EQ(topLevelCount(tv), 0);
     EXPECT_FALSE(tv->selectedItem().isValid());
 }
 
-TEST_F(TreeViewTest, SampleModelStructure) {
+TEST_F(TreeViewTest, SampleModelStructure)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -327,7 +348,8 @@ TEST_F(TreeViewTest, SampleModelStructure) {
     EXPECT_EQ(model->item(2)->rowCount(), 0);
 }
 
-TEST_F(TreeViewTest, DeepNesting) {
+TEST_F(TreeViewTest, DeepNesting)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -345,12 +367,14 @@ TEST_F(TreeViewTest, DeepNesting) {
 // Selection
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, DefaultSelectionMode) {
+TEST_F(TreeViewTest, DefaultSelectionMode)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_EQ(tv->selectionMode(), SelectionMode::Single);
 }
 
-TEST_F(TreeViewTest, SelectionModeSwitch) {
+TEST_F(TreeViewTest, SelectionModeSwitch)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
 
@@ -369,7 +393,8 @@ TEST_F(TreeViewTest, SelectionModeSwitch) {
     EXPECT_EQ(spy.count(), 3);
 }
 
-TEST_F(TreeViewTest, SelectionModeDuplicateIgnored) {
+TEST_F(TreeViewTest, SelectionModeDuplicateIgnored)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::selectionModeChanged);
 
@@ -377,7 +402,8 @@ TEST_F(TreeViewTest, SelectionModeDuplicateIgnored) {
     EXPECT_EQ(spy.count(), 0);
 }
 
-TEST_F(TreeViewTest, SetSelectedItem) {
+TEST_F(TreeViewTest, SetSelectedItem)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -385,7 +411,8 @@ TEST_F(TreeViewTest, SetSelectedItem) {
     EXPECT_EQ(tv->selectedItem(), model->index(0, 0));
 }
 
-TEST_F(TreeViewTest, ClearSelectionOnInvalidIndex) {
+TEST_F(TreeViewTest, ClearSelectionOnInvalidIndex)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -396,7 +423,8 @@ TEST_F(TreeViewTest, ClearSelectionOnInvalidIndex) {
     EXPECT_FALSE(tv->selectedItem().isValid());
 }
 
-TEST_F(TreeViewTest, IndicatorMotionDefaultsAndAnimationToggle) {
+TEST_F(TreeViewTest, IndicatorMotionDefaultsAndAnimationToggle)
+{
     TreeView* tv = new TreeView(window);
 
     EXPECT_DOUBLE_EQ(tv->indicatorMotionProgress(), 1.0);
@@ -414,7 +442,8 @@ TEST_F(TreeViewTest, IndicatorMotionDefaultsAndAnimationToggle) {
     EXPECT_DOUBLE_EQ(tv->indicatorMotionProgress(), 1.0);
 }
 
-TEST_F(TreeViewTest, IndicatorMotionClassifiesInitialUpwardDownwardAndSameLevel) {
+TEST_F(TreeViewTest, IndicatorMotionClassifiesInitialUpwardDownwardAndSameLevel)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setIndicatorMotionAnimationEnabled(false);
@@ -437,16 +466,19 @@ TEST_F(TreeViewTest, IndicatorMotionClassifiesInitialUpwardDownwardAndSameLevel)
     EXPECT_EQ(tv->indicatorMotionPreviousIndex(), work);
     EXPECT_EQ(tv->indicatorMotionCurrentIndex(), pictures);
     EXPECT_EQ(tv->indicatorMotionDirection(), TreeView::IndicatorVerticalDirection::Down);
-    EXPECT_EQ(tv->indicatorHierarchyTransition(), TreeView::IndicatorHierarchyTransition::SameLevel);
+    EXPECT_EQ(tv->indicatorHierarchyTransition(),
+              TreeView::IndicatorHierarchyTransition::SameLevel);
 
     tv->setSelectedItem(personal);
     processEvents();
     EXPECT_EQ(tv->indicatorMotionDirection(), TreeView::IndicatorVerticalDirection::Up);
-    EXPECT_EQ(tv->indicatorHierarchyTransition(), TreeView::IndicatorHierarchyTransition::SameLevel);
+    EXPECT_EQ(tv->indicatorHierarchyTransition(),
+              TreeView::IndicatorHierarchyTransition::SameLevel);
     EXPECT_DOUBLE_EQ(tv->selectedIndicatorProgress(personal), 1.0);
 }
 
-TEST_F(TreeViewTest, IndicatorMotionClassifiesHierarchyTransitions) {
+TEST_F(TreeViewTest, IndicatorMotionClassifiesHierarchyTransitions)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setIndicatorMotionAnimationEnabled(false);
@@ -468,7 +500,8 @@ TEST_F(TreeViewTest, IndicatorMotionClassifiesHierarchyTransitions) {
     tv->setSelectedItem(workChild1);
     processEvents();
     EXPECT_EQ(tv->indicatorMotionDirection(), TreeView::IndicatorVerticalDirection::Down);
-    EXPECT_EQ(tv->indicatorHierarchyTransition(), TreeView::IndicatorHierarchyTransition::SameLevel);
+    EXPECT_EQ(tv->indicatorHierarchyTransition(),
+              TreeView::IndicatorHierarchyTransition::SameLevel);
 
     tv->setSelectedItem(work);
     processEvents();
@@ -476,7 +509,8 @@ TEST_F(TreeViewTest, IndicatorMotionClassifiesHierarchyTransitions) {
     EXPECT_EQ(tv->indicatorHierarchyTransition(), TreeView::IndicatorHierarchyTransition::Outward);
 }
 
-TEST_F(TreeViewTest, IndicatorMotionClearsOnInvalidResetSelectionModelAndCollapse) {
+TEST_F(TreeViewTest, IndicatorMotionClearsOnInvalidResetSelectionModelAndCollapse)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setIndicatorMotionAnimationEnabled(false);
@@ -520,7 +554,8 @@ TEST_F(TreeViewTest, IndicatorMotionClearsOnInvalidResetSelectionModelAndCollaps
     EXPECT_FALSE(tv->indicatorMotionCurrentIndex().isValid());
 }
 
-TEST_F(TreeViewTest, IndicatorMotionSuppressesDuplicateSelectionAndSnapsWhenAnimationDisabled) {
+TEST_F(TreeViewTest, IndicatorMotionSuppressesDuplicateSelectionAndSnapsWhenAnimationDisabled)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setIndicatorMotionAnimationEnabled(false);
@@ -548,7 +583,8 @@ TEST_F(TreeViewTest, IndicatorMotionSuppressesDuplicateSelectionAndSnapsWhenAnim
     tv->setSelectedItem(personal);
     processEvents();
     EXPECT_EQ(tv->indicatorMotionDirection(), TreeView::IndicatorVerticalDirection::Down);
-    EXPECT_EQ(tv->indicatorHierarchyTransition(), TreeView::IndicatorHierarchyTransition::SameLevel);
+    EXPECT_EQ(tv->indicatorHierarchyTransition(),
+              TreeView::IndicatorHierarchyTransition::SameLevel);
     EXPECT_DOUBLE_EQ(tv->indicatorMotionProgress(), 1.0);
     const int directionAfterMove = directionSpy.count();
     const int hierarchyAfterMove = hierarchySpy.count();
@@ -561,7 +597,8 @@ TEST_F(TreeViewTest, IndicatorMotionSuppressesDuplicateSelectionAndSnapsWhenAnim
     EXPECT_EQ(progressSpy.count(), progressAfterMove);
 }
 
-TEST_F(TreeViewTest, IndicatorMotionProgressAnimatesWhenEnabled) {
+TEST_F(TreeViewTest, IndicatorMotionProgressAnimatesWhenEnabled)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -584,7 +621,8 @@ TEST_F(TreeViewTest, IndicatorMotionProgressAnimatesWhenEnabled) {
     EXPECT_DOUBLE_EQ(tv->selectedIndicatorProgress(personal), 1.0);
 }
 
-TEST_F(TreeViewTest, IndicatorMotionRepaintsWholeTransparentViewportDuringAnimation) {
+TEST_F(TreeViewTest, IndicatorMotionRepaintsWholeTransparentViewportDuringAnimation)
+{
     auto* tv = new PaintRegionTreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setBackgroundVisible(false);
@@ -610,7 +648,8 @@ TEST_F(TreeViewTest, IndicatorMotionRepaintsWholeTransparentViewportDuringAnimat
     EXPECT_TRUE(tv->observedFullViewportAnimatedPaint);
 }
 
-TEST_F(TreeViewTest, SelectionIndicatorVisibilityAndStyleSetters) {
+TEST_F(TreeViewTest, SelectionIndicatorVisibilityAndStyleSetters)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -659,12 +698,11 @@ TEST_F(TreeViewTest, SelectionIndicatorVisibilityAndStyleSetters) {
     model->item(0)->setData(42.0, kIndicatorInsetRole);
     tv->setSelectedItem(work);
     processEvents();
-    EXPECT_NEAR(tv->selectedIndicatorRect(1.0).left(),
-                tv->visualRect(work).left() + 42.0,
-                0.01);
+    EXPECT_NEAR(tv->selectedIndicatorRect(1.0).left(), tv->visualRect(work).left() + 42.0, 0.01);
 }
 
-TEST_F(TreeViewTest, NativeRowPanelIsSuppressedForDelegateOwnedBackgrounds) {
+TEST_F(TreeViewTest, NativeRowPanelIsSuppressedForDelegateOwnedBackgrounds)
+{
     TreeView tv;
     QImage image(120, defaultTreeRowHeight(), QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);
@@ -672,13 +710,11 @@ TEST_F(TreeViewTest, NativeRowPanelIsSuppressedForDelegateOwnedBackgrounds) {
     QStyleOptionViewItem option;
     option.initFrom(&tv);
     option.rect = image.rect();
-    option.state |= QStyle::State_Enabled | QStyle::State_Selected
-        | QStyle::State_MouseOver;
+    option.state |= QStyle::State_Enabled | QStyle::State_Selected | QStyle::State_MouseOver;
     option.palette.setColor(QPalette::Highlight, QColor(255, 0, 0, 255));
 
     QPainter painter(&image);
-    tv.style()->drawPrimitive(QStyle::PE_PanelItemViewRow,
-                              &option, &painter, &tv);
+    tv.style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &option, &painter, &tv);
     painter.end();
 
     for (int y = 0; y < image.height(); ++y) {
@@ -687,7 +723,8 @@ TEST_F(TreeViewTest, NativeRowPanelIsSuppressedForDelegateOwnedBackgrounds) {
     }
 }
 
-TEST_F(TreeViewTest, SelectionIndicatorPaintsAccentPillNearLeftOfSelectedRow) {
+TEST_F(TreeViewTest, SelectionIndicatorPaintsAccentPillNearLeftOfSelectedRow)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setSelectionIndicatorVisible(true);
@@ -710,7 +747,8 @@ TEST_F(TreeViewTest, SelectionIndicatorPaintsAccentPillNearLeftOfSelectedRow) {
     EXPECT_FALSE(hasAccentPixelInRect(tv->viewport(), rightProbe, accent));
 }
 
-TEST_F(TreeViewTest, AnimatedCollapseDefersModelCollapseUntilFinished) {
+TEST_F(TreeViewTest, AnimatedCollapseDefersModelCollapseUntilFinished)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -732,7 +770,8 @@ TEST_F(TreeViewTest, AnimatedCollapseDefersModelCollapseUntilFinished) {
     EXPECT_FALSE(tv->isExpanded(work));
 }
 
-TEST_F(TreeViewTest, AnimatedCollapseReversesBackToExpandedOnRetoggle) {
+TEST_F(TreeViewTest, AnimatedCollapseReversesBackToExpandedOnRetoggle)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -742,20 +781,21 @@ TEST_F(TreeViewTest, AnimatedCollapseReversesBackToExpandedOnRetoggle) {
     tv->toggleExpanded(work);
     for (int i = 0; i < 60 && !tv->isExpanded(work); ++i)
         QTest::qWait(10);
-    QTest::qWait(300);   // settle the expand reveal
+    QTest::qWait(300); // settle the expand reveal
     processEvents();
     ASSERT_TRUE(tv->isExpanded(work));
 
     // Begin an animated collapse, then immediately re-toggle to reverse it.
-    tv->toggleExpanded(work);   // start deferred collapse
-    QTest::qWait(40);           // let it run partway
-    tv->toggleExpanded(work);   // reverse → expand again
+    tv->toggleExpanded(work); // start deferred collapse
+    QTest::qWait(40);         // let it run partway
+    tv->toggleExpanded(work); // reverse → expand again
     QTest::qWait(320);
     processEvents();
-    EXPECT_TRUE(tv->isExpanded(work));   // never actually collapsed
+    EXPECT_TRUE(tv->isExpanded(work)); // never actually collapsed
 }
 
-TEST_F(TreeViewTest, ExpandRevealCommitsWhenAnotherParentToggles) {
+TEST_F(TreeViewTest, ExpandRevealCommitsWhenAnotherParentToggles)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -778,7 +818,8 @@ TEST_F(TreeViewTest, ExpandRevealCommitsWhenAnotherParentToggles) {
     EXPECT_DOUBLE_EQ(tv->chevronRotation(work), 1.0);
 }
 
-TEST_F(TreeViewTest, CollapseRevealFinalizesWhenAnotherParentToggles) {
+TEST_F(TreeViewTest, CollapseRevealFinalizesWhenAnotherParentToggles)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -806,7 +847,8 @@ TEST_F(TreeViewTest, CollapseRevealFinalizesWhenAnotherParentToggles) {
     EXPECT_FALSE(tv->isExpanded(personal));
 }
 
-TEST_F(TreeViewTest, AnimatedCollapseHitTestingFollowsVisualRows) {
+TEST_F(TreeViewTest, AnimatedCollapseHitTestingFollowsVisualRows)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -822,7 +864,8 @@ TEST_F(TreeViewTest, AnimatedCollapseHitTestingFollowsVisualRows) {
     processEvents();
     ASSERT_TRUE(tv->isExpanded(work));
 
-    const qreal subtreeHeight = tv->visualRect(firstChild).height() + tv->visualRect(secondChild).height();
+    const qreal subtreeHeight =
+        tv->visualRect(firstChild).height() + tv->visualRect(secondChild).height();
     const QRect personalRect = tv->visualRect(personal);
     ASSERT_FALSE(personalRect.isEmpty());
 
@@ -834,8 +877,8 @@ TEST_F(TreeViewTest, AnimatedCollapseHitTestingFollowsVisualRows) {
     ASSERT_GT(progress, 0.0);
     ASSERT_LT(progress, 1.0);
 
-    const QPoint visualPersonalCenter = personalRect.center()
-        - QPoint(0, qRound(subtreeHeight * (1.0 - progress)));
+    const QPoint visualPersonalCenter =
+        personalRect.center() - QPoint(0, qRound(subtreeHeight * (1.0 - progress)));
     EXPECT_EQ(tv->indexAt(visualPersonalCenter), personal);
 
     QTest::mouseClick(tv->viewport(), Qt::LeftButton, Qt::NoModifier, visualPersonalCenter);
@@ -847,7 +890,8 @@ TEST_F(TreeViewTest, AnimatedCollapseHitTestingFollowsVisualRows) {
 // Expand / Collapse
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, ExpandCollapseTopLevel) {
+TEST_F(TreeViewTest, ExpandCollapseTopLevel)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -865,7 +909,8 @@ TEST_F(TreeViewTest, ExpandCollapseTopLevel) {
     EXPECT_FALSE(tv->isExpanded(workIdx));
 }
 
-TEST_F(TreeViewTest, ToggleExpanded) {
+TEST_F(TreeViewTest, ToggleExpanded)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -878,7 +923,8 @@ TEST_F(TreeViewTest, ToggleExpanded) {
     EXPECT_FALSE(tv->isExpanded(workIdx));
 }
 
-TEST_F(TreeViewTest, ExpandAll) {
+TEST_F(TreeViewTest, ExpandAll)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -890,7 +936,8 @@ TEST_F(TreeViewTest, ExpandAll) {
     EXPECT_TRUE(tv->isExpanded(model->item(1)->child(0)->index()));
 }
 
-TEST_F(TreeViewTest, CollapseAll) {
+TEST_F(TreeViewTest, CollapseAll)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -901,7 +948,8 @@ TEST_F(TreeViewTest, CollapseAll) {
     EXPECT_FALSE(tv->isExpanded(model->index(1, 0)));
 }
 
-TEST_F(TreeViewTest, ToggleInvalidIndexNoOp) {
+TEST_F(TreeViewTest, ToggleInvalidIndexNoOp)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
 
@@ -913,7 +961,8 @@ TEST_F(TreeViewTest, ToggleInvalidIndexNoOp) {
 // Expand Animation
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, ExpandAnimationTriggered) {
+TEST_F(TreeViewTest, ExpandAnimationTriggered)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -928,7 +977,8 @@ TEST_F(TreeViewTest, ExpandAnimationTriggered) {
     EXPECT_TRUE(tv->isExpanded(workIdx));
 }
 
-TEST_F(TreeViewTest, ExpandAnimationExposesChildrenDuringReveal) {
+TEST_F(TreeViewTest, ExpandAnimationExposesChildrenDuringReveal)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -947,7 +997,8 @@ TEST_F(TreeViewTest, ExpandAnimationExposesChildrenDuringReveal) {
     EXPECT_FALSE(tv->visualRect(childIdx).isEmpty());
 }
 
-TEST_F(TreeViewTest, ExpandAnimationCompletesCleanly) {
+TEST_F(TreeViewTest, ExpandAnimationCompletesCleanly)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -966,7 +1017,8 @@ TEST_F(TreeViewTest, ExpandAnimationCompletesCleanly) {
     EXPECT_GT(model->rowCount(workIdx), 0);
 }
 
-TEST_F(TreeViewTest, RapidToggleNoCrash) {
+TEST_F(TreeViewTest, RapidToggleNoCrash)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -984,7 +1036,8 @@ TEST_F(TreeViewTest, RapidToggleNoCrash) {
     SUCCEED();
 }
 
-TEST_F(TreeViewTest, ExpandAllSkipsAnimation) {
+TEST_F(TreeViewTest, ExpandAllSkipsAnimation)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -999,7 +1052,8 @@ TEST_F(TreeViewTest, ExpandAllSkipsAnimation) {
     EXPECT_TRUE(tv->isExpanded(model->index(1, 0)));
 }
 
-TEST_F(TreeViewTest, CollapseStopsExpandAnimation) {
+TEST_F(TreeViewTest, CollapseStopsExpandAnimation)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->resize(300, 400);
@@ -1023,13 +1077,15 @@ TEST_F(TreeViewTest, CollapseStopsExpandAnimation) {
 // Appearance Properties
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, DefaultBorderVisible) {
+TEST_F(TreeViewTest, DefaultBorderVisible)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_TRUE(tv->borderVisible());
     EXPECT_TRUE(tv->isBorderVisible());
 }
 
-TEST_F(TreeViewTest, SetBorderVisible) {
+TEST_F(TreeViewTest, SetBorderVisible)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::borderVisibleChanged);
 
@@ -1042,13 +1098,15 @@ TEST_F(TreeViewTest, SetBorderVisible) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, DefaultBackgroundVisible) {
+TEST_F(TreeViewTest, DefaultBackgroundVisible)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_TRUE(tv->backgroundVisible());
     EXPECT_TRUE(tv->isBackgroundVisible());
 }
 
-TEST_F(TreeViewTest, SetBackgroundVisible) {
+TEST_F(TreeViewTest, SetBackgroundVisible)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::backgroundVisibleChanged);
 
@@ -1058,7 +1116,8 @@ TEST_F(TreeViewTest, SetBackgroundVisible) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, HeaderText) {
+TEST_F(TreeViewTest, HeaderText)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::headerTextChanged);
 
@@ -1072,7 +1131,8 @@ TEST_F(TreeViewTest, HeaderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, PlaceholderText) {
+TEST_F(TreeViewTest, PlaceholderText)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::placeholderTextChanged);
 
@@ -1081,7 +1141,8 @@ TEST_F(TreeViewTest, PlaceholderText) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, FontRole) {
+TEST_F(TreeViewTest, FontRole)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::fontRoleChanged);
 
@@ -1099,17 +1160,20 @@ TEST_F(TreeViewTest, FontRole) {
 // Tree-specific
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, IndentationDefault) {
+TEST_F(TreeViewTest, IndentationDefault)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_EQ(tv->indentation(), 16);
 }
 
-TEST_F(TreeViewTest, RootIsDecoratedOff) {
+TEST_F(TreeViewTest, RootIsDecoratedOff)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_FALSE(tv->rootIsDecorated());
 }
 
-TEST_F(TreeViewTest, HeaderHiddenByDefault) {
+TEST_F(TreeViewTest, HeaderHiddenByDefault)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_TRUE(tv->isHeaderHidden());
 }
@@ -1118,16 +1182,18 @@ TEST_F(TreeViewTest, HeaderHiddenByDefault) {
 // Fluent Scroll Bar
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, FluentScrollBarExists) {
+TEST_F(TreeViewTest, FluentScrollBarExists)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_NE(tv->verticalFluentScrollBar(), nullptr);
     EXPECT_NE(tv->horizontalFluentScrollBar(), nullptr);
 }
 
-TEST_F(TreeViewTest, FluentScrollBarHiddenWhenShort) {
+TEST_F(TreeViewTest, FluentScrollBarHiddenWhenShort)
+{
     TreeView* tv = new TreeView(window);
     tv->setFixedSize(300, 400);
-    attachSampleModel(tv);  // only 3 top-level items, should fit
+    attachSampleModel(tv); // only 3 top-level items, should fit
 
     showOffscreen(window);
 
@@ -1135,9 +1201,10 @@ TEST_F(TreeViewTest, FluentScrollBarHiddenWhenShort) {
     EXPECT_FALSE(tv->verticalFluentScrollBar()->isVisible());
 }
 
-TEST_F(TreeViewTest, FluentScrollBarVisibleWhenTall) {
+TEST_F(TreeViewTest, FluentScrollBarVisibleWhenTall)
+{
     TreeView* tv = new TreeView(window);
-    tv->setFixedSize(300, 60);  // very small → will need scrolling
+    tv->setFixedSize(300, 60); // very small → will need scrolling
 
     auto* model = new QStandardItemModel(tv);
     for (int i = 0; i < 20; ++i) {
@@ -1156,7 +1223,8 @@ TEST_F(TreeViewTest, FluentScrollBarVisibleWhenTall) {
 // itemClicked signal
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, ItemClickedSignalEmitted) {
+TEST_F(TreeViewTest, ItemClickedSignalEmitted)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(300, 400);
@@ -1177,7 +1245,8 @@ TEST_F(TreeViewTest, ItemClickedSignalEmitted) {
     EXPECT_EQ(clickedIdx, idx);
 }
 
-TEST_F(TreeViewTest, ItemPressedSignalEmittedOnMousePress) {
+TEST_F(TreeViewTest, ItemPressedSignalEmittedOnMousePress)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(300, 400);
@@ -1204,7 +1273,8 @@ TEST_F(TreeViewTest, ItemPressedSignalEmittedOnMousePress) {
 // Chevron-only expand & checkbox click
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, ClickRowBodyDoesNotExpand) {
+TEST_F(TreeViewTest, ClickRowBodyDoesNotExpand)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -1221,7 +1291,8 @@ TEST_F(TreeViewTest, ClickRowBodyDoesNotExpand) {
     EXPECT_FALSE(tv->isExpanded(workIdx));
 }
 
-TEST_F(TreeViewTest, ClickChevronAreaExpands) {
+TEST_F(TreeViewTest, ClickChevronAreaExpands)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -1246,7 +1317,8 @@ TEST_F(TreeViewTest, ClickChevronAreaExpands) {
     EXPECT_FALSE(tv->isExpanded(workIdx));
 }
 
-TEST_F(TreeViewTest, CheckBoxClickTogglesState) {
+TEST_F(TreeViewTest, CheckBoxClickTogglesState)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -1273,7 +1345,8 @@ TEST_F(TreeViewTest, CheckBoxClickTogglesState) {
     EXPECT_EQ(model->item(2)->checkState(), Qt::Unchecked);
 }
 
-TEST_F(TreeViewTest, ParentCheckCascadesToChildren) {
+TEST_F(TreeViewTest, ParentCheckCascadesToChildren)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -1305,7 +1378,8 @@ TEST_F(TreeViewTest, ParentCheckCascadesToChildren) {
     EXPECT_EQ(model->item(0)->child(1)->checkState(), Qt::Unchecked);
 }
 
-TEST_F(TreeViewTest, ChildCheckUpdatesParentTriState) {
+TEST_F(TreeViewTest, ChildCheckUpdatesParentTriState)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -1336,7 +1410,8 @@ TEST_F(TreeViewTest, ChildCheckUpdatesParentTriState) {
     EXPECT_EQ(personal->checkState(), Qt::Checked);
 }
 
-TEST_F(TreeViewTest, DeepCascadeGrandchildren) {
+TEST_F(TreeViewTest, DeepCascadeGrandchildren)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -1368,7 +1443,8 @@ TEST_F(TreeViewTest, DeepCascadeGrandchildren) {
     EXPECT_EQ(remodel->child(1)->checkState(), Qt::Checked);
 }
 
-TEST_F(TreeViewTest, ChevronRotationApi) {
+TEST_F(TreeViewTest, ChevronRotationApi)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(300, 400);
@@ -1392,12 +1468,14 @@ TEST_F(TreeViewTest, ChevronRotationApi) {
 // Drag reorder (file-manager style)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, DefaultCanReorderItems) {
+TEST_F(TreeViewTest, DefaultCanReorderItems)
+{
     TreeView* tv = new TreeView(window);
     EXPECT_FALSE(tv->canReorderItems());
 }
 
-TEST_F(TreeViewTest, SetCanReorderItems) {
+TEST_F(TreeViewTest, SetCanReorderItems)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::canReorderItemsChanged);
     tv->setCanReorderItems(true);
@@ -1405,7 +1483,8 @@ TEST_F(TreeViewTest, SetCanReorderItems) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, CanReorderItemsSignalNotDuplicate) {
+TEST_F(TreeViewTest, CanReorderItemsSignalNotDuplicate)
+{
     TreeView* tv = new TreeView(window);
     QSignalSpy spy(tv, &TreeView::canReorderItemsChanged);
     tv->setCanReorderItems(true);
@@ -1413,7 +1492,8 @@ TEST_F(TreeViewTest, CanReorderItemsSignalNotDuplicate) {
     EXPECT_EQ(spy.count(), 1);
 }
 
-TEST_F(TreeViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
+TEST_F(TreeViewTest, ScrollChainingPropertyControlsBoundaryWheel)
+{
     auto* tv = new TreeView(window);
     tv->setGeometry(0, 0, 260, 140);
     auto* model = new QStandardItemModel(tv);
@@ -1450,7 +1530,8 @@ TEST_F(TreeViewTest, ScrollChainingPropertyControlsBoundaryWheel) {
     EXPECT_TRUE(containedWheel.isAccepted());
 }
 
-TEST_F(TreeViewTest, WheelPassesThroughWhenContentFits) {
+TEST_F(TreeViewTest, WheelPassesThroughWhenContentFits)
+{
     auto* tv = new TreeView(window);
     tv->setGeometry(0, 0, 300, 220);
     auto* model = new QStandardItemModel(tv);
@@ -1471,7 +1552,8 @@ TEST_F(TreeViewTest, WheelPassesThroughWhenContentFits) {
     EXPECT_FALSE(wheel.isAccepted());
 }
 
-TEST_F(TreeViewTest, DragReorderTopLevelSiblings) {
+TEST_F(TreeViewTest, DragReorderTopLevelSiblings)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setCanReorderItems(true);
@@ -1491,7 +1573,8 @@ TEST_F(TreeViewTest, DragReorderTopLevelSiblings) {
     EXPECT_EQ(model->item(2)->text(), "Pictures");
 }
 
-TEST_F(TreeViewTest, DragReorderChildSiblings) {
+TEST_F(TreeViewTest, DragReorderChildSiblings)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setCanReorderItems(true);
@@ -1511,7 +1594,8 @@ TEST_F(TreeViewTest, DragReorderChildSiblings) {
     EXPECT_EQ(work->child(1)->text(), "XYZ Functional Spec");
 }
 
-TEST_F(TreeViewTest, DragReorderEmitsSignal) {
+TEST_F(TreeViewTest, DragReorderEmitsSignal)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setCanReorderItems(true);
@@ -1533,14 +1617,14 @@ TEST_F(TreeViewTest, DragReorderEmitsSignal) {
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, start);
     // Move past drag distance
     QPoint moved(start.x(), start.y() + QApplication::startDragDistance() + 5);
-    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent1);
     QApplication::processEvents();
 
     // Move to target
-    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent2);
     QApplication::processEvents();
 
@@ -1555,7 +1639,8 @@ TEST_F(TreeViewTest, DragReorderEmitsSignal) {
     EXPECT_EQ(model->item(2)->text(), "Pictures");
 }
 
-TEST_F(TreeViewTest, DragDisabledDoesNotReorder) {
+TEST_F(TreeViewTest, DragDisabledDoesNotReorder)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setCanReorderItems(false);
@@ -1572,8 +1657,8 @@ TEST_F(TreeViewTest, DragDisabledDoesNotReorder) {
 
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, start);
     QPoint moved(start.x(), start.y() + QApplication::startDragDistance() + 5);
-    QMouseEvent moveEvent(QEvent::MouseMove, QPointF(moved), QPointF(moved),
-                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent(QEvent::MouseMove, QPointF(moved), QPointF(moved), Qt::LeftButton,
+                          Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent);
     QApplication::processEvents();
     QTest::mouseRelease(tv->viewport(), Qt::LeftButton, Qt::NoModifier, end);
@@ -1585,7 +1670,8 @@ TEST_F(TreeViewTest, DragDisabledDoesNotReorder) {
     EXPECT_EQ(model->item(2)->text(), "Pictures");
 }
 
-TEST_F(TreeViewTest, DragPreservesChildHierarchy) {
+TEST_F(TreeViewTest, DragPreservesChildHierarchy)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setCanReorderItems(true);
@@ -1605,7 +1691,8 @@ TEST_F(TreeViewTest, DragPreservesChildHierarchy) {
     EXPECT_EQ(work->child(1)->text(), "Feature Schedule");
 }
 
-TEST_F(TreeViewTest, DragDropOntoFolder) {
+TEST_F(TreeViewTest, DragDropOntoFolder)
+{
     // File-manager style: drag an item onto a folder (item with children)
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
@@ -1630,12 +1717,12 @@ TEST_F(TreeViewTest, DragDropOntoFolder) {
 
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, start);
     QPoint moved(start.x(), start.y() - QApplication::startDragDistance() - 5);
-    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent1);
     QApplication::processEvents();
-    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent2);
     QApplication::processEvents();
     QTest::mouseRelease(tv->viewport(), Qt::LeftButton, Qt::NoModifier, end);
@@ -1647,7 +1734,8 @@ TEST_F(TreeViewTest, DragDropOntoFolder) {
     EXPECT_EQ(work->child(work->rowCount() - 1)->text(), "Pictures");
 }
 
-TEST_F(TreeViewTest, DragCrossParentBetween) {
+TEST_F(TreeViewTest, DragCrossParentBetween)
+{
     // File-manager style: drag child item to root level (between root items)
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
@@ -1672,24 +1760,25 @@ TEST_F(TreeViewTest, DragCrossParentBetween) {
 
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, start);
     QPoint moved(start.x(), start.y() + QApplication::startDragDistance() + 5);
-    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent1);
     QApplication::processEvents();
-    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent2);
     QApplication::processEvents();
     QTest::mouseRelease(tv->viewport(), Qt::LeftButton, Qt::NoModifier, end);
     QApplication::processEvents();
 
     // "XYZ Functional Spec" removed from Work Documents, inserted at root level
-    EXPECT_EQ(work->rowCount(), 1);    // only 1 child left
-    EXPECT_EQ(model->rowCount(), 4);   // 4 root items now
+    EXPECT_EQ(work->rowCount(), 1);  // only 1 child left
+    EXPECT_EQ(model->rowCount(), 4); // 4 root items now
     EXPECT_EQ(model->item(1)->text(), "XYZ Functional Spec");
 }
 
-TEST_F(TreeViewTest, DragCannotDropAncestorOntoDescendant) {
+TEST_F(TreeViewTest, DragCannotDropAncestorOntoDescendant)
+{
     // Cycle prevention: dragging a parent onto its own child should be ignored
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
@@ -1712,12 +1801,12 @@ TEST_F(TreeViewTest, DragCannotDropAncestorOntoDescendant) {
 
     QTest::mousePress(tv->viewport(), Qt::LeftButton, Qt::NoModifier, start);
     QPoint moved(start.x(), start.y() + QApplication::startDragDistance() + 5);
-    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent1(QEvent::MouseMove, QPointF(moved), QPointF(moved), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent1);
     QApplication::processEvents();
-    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end),
-                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent moveEvent2(QEvent::MouseMove, QPointF(end), QPointF(end), Qt::LeftButton,
+                           Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(tv->viewport(), &moveEvent2);
     QApplication::processEvents();
     QTest::mouseRelease(tv->viewport(), Qt::LeftButton, Qt::NoModifier, end);
@@ -1733,7 +1822,8 @@ TEST_F(TreeViewTest, DragCannotDropAncestorOntoDescendant) {
 // Theme
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, ThemeSwitchDoesNotCrash) {
+TEST_F(TreeViewTest, ThemeSwitchDoesNotCrash)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
 
@@ -1752,7 +1842,8 @@ TEST_F(TreeViewTest, ThemeSwitchDoesNotCrash) {
 // Dynamic model changes
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, AddRemoveTopLevelItems) {
+TEST_F(TreeViewTest, AddRemoveTopLevelItems)
+{
     TreeView* tv = new TreeView(window);
     auto* model = new QStandardItemModel(tv);
     tv->setModel(model);
@@ -1771,7 +1862,8 @@ TEST_F(TreeViewTest, AddRemoveTopLevelItems) {
     EXPECT_EQ(model->item(0)->text(), "Root 2");
 }
 
-TEST_F(TreeViewTest, AddChildrenDynamically) {
+TEST_F(TreeViewTest, AddChildrenDynamically)
+{
     TreeView* tv = new TreeView(window);
     auto* model = new QStandardItemModel(tv);
     tv->setModel(model);
@@ -1794,7 +1886,8 @@ TEST_F(TreeViewTest, AddChildrenDynamically) {
 // Delegate
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, DelegateSizeHint) {
+TEST_F(TreeViewTest, DelegateSizeHint)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
 
@@ -1803,7 +1896,8 @@ TEST_F(TreeViewTest, DelegateSizeHint) {
     EXPECT_EQ(delegate->rowHeight(), defaultTreeRowHeight());
 }
 
-TEST_F(TreeViewTest, DelegateCustomRowHeight) {
+TEST_F(TreeViewTest, DelegateCustomRowHeight)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
 
@@ -1817,7 +1911,8 @@ TEST_F(TreeViewTest, DelegateCustomRowHeight) {
     EXPECT_EQ(hint.height(), 48);
 }
 
-TEST_F(TreeViewTest, DelegateConsumesIndicatorMotionWithoutChangingRowMetrics) {
+TEST_F(TreeViewTest, DelegateConsumesIndicatorMotionWithoutChangingRowMetrics)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     auto* delegate = qobject_cast<treeview_test::FluentTreeItemDelegate*>(tv->itemDelegate());
@@ -1850,7 +1945,8 @@ TEST_F(TreeViewTest, DelegateConsumesIndicatorMotionWithoutChangingRowMetrics) {
     EXPECT_DOUBLE_EQ(tv->selectedIndicatorProgress(personal), 1.0);
 }
 
-TEST_F(TreeViewTest, DelegateSkipsAccentBarWhenTreeViewOverlayIndicatorVisible) {
+TEST_F(TreeViewTest, DelegateSkipsAccentBarWhenTreeViewOverlayIndicatorVisible)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     auto* delegate = qobject_cast<treeview_test::FluentTreeItemDelegate*>(tv->itemDelegate());
@@ -1887,7 +1983,8 @@ TEST_F(TreeViewTest, DelegateSkipsAccentBarWhenTreeViewOverlayIndicatorVisible) 
     EXPECT_FALSE(hasAccentPixelInImage(renderDelegateRow(), indicatorProbe, accent));
 }
 
-TEST_F(TreeViewTest, DelegateSelectedIndicatorFollowsHierarchicalRowLocalPosition) {
+TEST_F(TreeViewTest, DelegateSelectedIndicatorFollowsHierarchicalRowLocalPosition)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setIndicatorMotionAnimationEnabled(false);
@@ -1916,7 +2013,8 @@ TEST_F(TreeViewTest, DelegateSelectedIndicatorFollowsHierarchicalRowLocalPositio
     EXPECT_GT(childAccentX, parentAccentX);
 }
 
-TEST_F(TreeViewTest, SelectedIndicatorAnchorsToTargetDuringHierarchyTransitions) {
+TEST_F(TreeViewTest, SelectedIndicatorAnchorsToTargetDuringHierarchyTransitions)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -1958,7 +2056,8 @@ TEST_F(TreeViewTest, SelectedIndicatorAnchorsToTargetDuringHierarchyTransitions)
     EXPECT_NEAR(outwardMid.height(), outwardTarget.height(), 0.01);
 }
 
-TEST_F(TreeViewTest, CollapsingParentAfterChildToParentSelectionKeepsParentIndicator) {
+TEST_F(TreeViewTest, CollapsingParentAfterChildToParentSelectionKeepsParentIndicator)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(350, 400);
@@ -1994,7 +2093,8 @@ TEST_F(TreeViewTest, CollapsingParentAfterChildToParentSelectionKeepsParentIndic
 // paint / render (no crash)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, PaintWithExpandedItems) {
+TEST_F(TreeViewTest, PaintWithExpandedItems)
+{
     TreeView* tv = new TreeView(window);
     auto* model = attachSampleModel(tv);
     tv->setFixedSize(300, 400);
@@ -2010,7 +2110,8 @@ TEST_F(TreeViewTest, PaintWithExpandedItems) {
     EXPECT_TRUE(true);
 }
 
-TEST_F(TreeViewTest, PaintEmptyWithPlaceholder) {
+TEST_F(TreeViewTest, PaintEmptyWithPlaceholder)
+{
     TreeView* tv = new TreeView(window);
     tv->setPlaceholderText("Empty tree");
     tv->setFixedSize(300, 400);
@@ -2024,14 +2125,16 @@ TEST_F(TreeViewTest, PaintEmptyWithPlaceholder) {
 // CheckBox delegate
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, CheckBoxVisibleDefault) {
+TEST_F(TreeViewTest, CheckBoxVisibleDefault)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
     auto* d = qobject_cast<treeview_test::FluentTreeItemDelegate*>(tv->itemDelegate());
     EXPECT_FALSE(d->checkBoxVisible());
 }
 
-TEST_F(TreeViewTest, CheckBoxVisibleToggle) {
+TEST_F(TreeViewTest, CheckBoxVisibleToggle)
+{
     TreeView* tv = new TreeView(window);
     attachSampleModel(tv);
     auto* d = qobject_cast<treeview_test::FluentTreeItemDelegate*>(tv->itemDelegate());
@@ -2041,7 +2144,8 @@ TEST_F(TreeViewTest, CheckBoxVisibleToggle) {
     EXPECT_FALSE(d->checkBoxVisible());
 }
 
-TEST_F(TreeViewTest, CheckableModelPaintNoCrash) {
+TEST_F(TreeViewTest, CheckableModelPaintNoCrash)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -2054,7 +2158,8 @@ TEST_F(TreeViewTest, CheckableModelPaintNoCrash) {
     EXPECT_TRUE(true);
 }
 
-TEST_F(TreeViewTest, CheckStateTracksMultiSelectionChanges) {
+TEST_F(TreeViewTest, CheckStateTracksMultiSelectionChanges)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -2104,7 +2209,8 @@ TEST_F(TreeViewTest, CheckStateTracksMultiSelectionChanges) {
     EXPECT_EQ(model->item(0)->child(1)->checkState(), Qt::Unchecked);
 }
 
-TEST_F(TreeViewTest, CheckBoxClickSyncsMultiSelection) {
+TEST_F(TreeViewTest, CheckBoxClickSyncsMultiSelection)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -2128,7 +2234,8 @@ TEST_F(TreeViewTest, CheckBoxClickSyncsMultiSelection) {
     EXPECT_EQ(model->item(2)->checkState(), Qt::Unchecked);
 }
 
-TEST_F(TreeViewTest, CheckBoxParentAndChildClicksKeepTriStateSelection) {
+TEST_F(TreeViewTest, CheckBoxParentAndChildClicksKeepTriStateSelection)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -2181,7 +2288,8 @@ TEST_F(TreeViewTest, CheckBoxParentAndChildClicksKeepTriStateSelection) {
     EXPECT_EQ(model->item(0)->child(1)->checkState(), Qt::Unchecked);
 }
 
-TEST_F(TreeViewTest, CheckableSelectionDoesNotPaintIndicator) {
+TEST_F(TreeViewTest, CheckableSelectionDoesNotPaintIndicator)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createCheckableTreeModel(tv);
     tv->setModel(model);
@@ -2205,7 +2313,8 @@ TEST_F(TreeViewTest, CheckableSelectionDoesNotPaintIndicator) {
     EXPECT_TRUE(hasAccentPixelInRect(tv->viewport(), checkboxArea, accent));
 }
 
-TEST_F(TreeViewTest, CheckStateRoleRead) {
+TEST_F(TreeViewTest, CheckStateRoleRead)
+{
     auto* model = createCheckableTreeModel(nullptr);
     // Work Documents → PartiallyChecked
     EXPECT_EQ(model->item(0)->checkState(), Qt::PartiallyChecked);
@@ -2220,7 +2329,8 @@ TEST_F(TreeViewTest, CheckStateRoleRead) {
 // Icon glyph delegate
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, IconGlyphRoleRead) {
+TEST_F(TreeViewTest, IconGlyphRoleRead)
+{
     auto* model = createIconTreeModel(nullptr);
     // Work Documents → Folder icon
     EXPECT_EQ(model->item(0)->data(treeview_test::IconGlyphRole).toString(),
@@ -2231,7 +2341,8 @@ TEST_F(TreeViewTest, IconGlyphRoleRead) {
     delete model;
 }
 
-TEST_F(TreeViewTest, IconModelPaintNoCrash) {
+TEST_F(TreeViewTest, IconModelPaintNoCrash)
+{
     TreeView* tv = new TreeView(window);
     auto* model = createIconTreeModel(tv);
     tv->setModel(model);
@@ -2247,7 +2358,8 @@ TEST_F(TreeViewTest, IconModelPaintNoCrash) {
 // VisualCheck
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST_F(TreeViewTest, VisualCheck) {
+TEST_F(TreeViewTest, VisualCheck)
+{
     if (qEnvironmentVariableIsSet("SKIP_VISUAL_TEST")) {
         GTEST_SKIP() << "Set SKIP_VISUAL_TEST=1 to skip visual tests";
     }
@@ -2267,15 +2379,16 @@ TEST_F(TreeViewTest, VisualCheck) {
     auto* fluentVBar = new fluent::scrolling::ScrollBar(Qt::Vertical, scrollArea);
     fluentVBar->setObjectName("fluentScrollAreaVBar");
     auto* nativeVBar = scrollArea->verticalScrollBar();
-    QObject::connect(nativeVBar,  &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
-    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar,  &QScrollBar::setValue);
+    QObject::connect(nativeVBar, &QScrollBar::valueChanged, fluentVBar, &QScrollBar::setValue);
+    QObject::connect(fluentVBar, &QScrollBar::valueChanged, nativeVBar, &QScrollBar::setValue);
 
     auto syncFluentBar = [scrollArea, fluentVBar, nativeVBar]() {
         fluentVBar->setRange(nativeVBar->minimum(), nativeVBar->maximum());
         fluentVBar->setPageStep(nativeVBar->pageStep());
         const bool need = nativeVBar->maximum() > nativeVBar->minimum();
         fluentVBar->setVisible(need);
-        if (!need) return;
+        if (!need)
+            return;
         const QRect r = scrollArea->rect();
         const int x = r.right() - fluentVBar->thickness() + 1;
         fluentVBar->setGeometry(x, r.top() + 2, fluentVBar->thickness(), r.height() - 4);
@@ -2375,21 +2488,21 @@ TEST_F(TreeViewTest, VisualCheck) {
         auto* model = createSampleTreeModel(tv1);
         tv1->setModel(model);
         attachFluentDelegate(tv1);
-        tv1->expand(model->index(0, 0));  // Work Documents
-        tv1->expand(model->index(1, 0));  // Personal Documents
-        tv1->expand(model->item(1)->child(0)->index()); // Home Remodel
+        tv1->expand(model->index(0, 0));                         // Work Documents
+        tv1->expand(model->index(1, 0));                         // Personal Documents
+        tv1->expand(model->item(1)->child(0)->index());          // Home Remodel
         tv1->setSelectedItem(model->item(0)->child(0)->index()); // XYZ Functional Spec
     }
     tv1->setFixedHeight(300);
-    tv1->anchors()->top   = {motionTree, Edge::Bottom,  16};
-    tv1->anchors()->left  = {content, Edge::Left, 20};
+    tv1->anchors()->top = {motionTree, Edge::Bottom, 16};
+    tv1->anchors()->left = {content, Edge::Left, 20};
     tv1->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(tv1);
 
     // ── TreeView 2: Multi-selection with CheckBox ────────────────────────
     Label* header2 = new Label("A TreeView with Multi-selection enabled.", content);
     header2->setFluentTypography(Typography::FontRole::BodyStrong);
-    header2->anchors()->top  = {tv1, Edge::Bottom, 16};
+    header2->anchors()->top = {tv1, Edge::Bottom, 16};
     header2->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header2);
 
@@ -2403,21 +2516,21 @@ TEST_F(TreeViewTest, VisualCheck) {
             static_cast<fluent::FluentElement*>(tv2), defaultTreeRowHeight(), tv2, tv2);
         d->setCheckBoxVisible(true);
         tv2->setItemDelegate(d);
-        tv2->expand(model->index(0, 0));  // Work Documents
-        tv2->expand(model->index(1, 0));  // Personal Documents
+        tv2->expand(model->index(0, 0));                // Work Documents
+        tv2->expand(model->index(1, 0));                // Personal Documents
         tv2->expand(model->item(1)->child(0)->index()); // Home Remodel
         selectCheckedRows(tv2);
     }
     tv2->setFixedHeight(300);
-    tv2->anchors()->top   = {header2, Edge::Bottom, 8};
-    tv2->anchors()->left  = {content, Edge::Left, 20};
+    tv2->anchors()->top = {header2, Edge::Bottom, 8};
+    tv2->anchors()->left = {content, Edge::Left, 20};
     tv2->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(tv2);
 
     // ── TreeView 3: DataBinding using ItemSource ─────────────────────────
     Label* header3 = new Label("A TreeView with DataBinding Using ItemSource.", content);
     header3->setFluentTypography(Typography::FontRole::BodyStrong);
-    header3->anchors()->top  = {tv2, Edge::Bottom, 16};
+    header3->anchors()->top = {tv2, Edge::Bottom, 16};
     header3->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header3);
 
@@ -2453,18 +2566,18 @@ TEST_F(TreeViewTest, VisualCheck) {
 
         tv3->setModel(model);
         attachFluentDelegate(tv3);
-        tv3->expand(model->index(1, 0));  // Documents
+        tv3->expand(model->index(1, 0)); // Documents
     }
     tv3->setFixedHeight(280);
-    tv3->anchors()->top   = {header3, Edge::Bottom, 8};
-    tv3->anchors()->left  = {content, Edge::Left, 20};
+    tv3->anchors()->top = {header3, Edge::Bottom, 8};
+    tv3->anchors()->left = {content, Edge::Left, 20};
     tv3->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(tv3);
 
     // ── TreeView 4: ItemTemplateSelector (folder/document icons) ─────────
     Label* header4 = new Label("A TreeView with ItemTemplateSelector.", content);
     header4->setFluentTypography(Typography::FontRole::BodyStrong);
-    header4->anchors()->top  = {tv3, Edge::Bottom, 16};
+    header4->anchors()->top = {tv3, Edge::Bottom, 16};
     header4->anchors()->left = {content, Edge::Left, 20};
     innerLayout->addWidget(header4);
 
@@ -2474,13 +2587,13 @@ TEST_F(TreeViewTest, VisualCheck) {
         auto* model = createIconTreeModel(tv4);
         tv4->setModel(model);
         attachFluentDelegate(tv4);
-        tv4->expand(model->index(0, 0));  // Work Documents
-        tv4->expand(model->index(1, 0));  // Personal Documents
+        tv4->expand(model->index(0, 0));                // Work Documents
+        tv4->expand(model->index(1, 0));                // Personal Documents
         tv4->expand(model->item(1)->child(0)->index()); // Home Remodel
     }
     tv4->setFixedHeight(300);
-    tv4->anchors()->top   = {header4, Edge::Bottom, 8};
-    tv4->anchors()->left  = {content, Edge::Left, 20};
+    tv4->anchors()->top = {header4, Edge::Bottom, 8};
+    tv4->anchors()->left = {content, Edge::Left, 20};
     tv4->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(tv4);
 
@@ -2488,7 +2601,7 @@ TEST_F(TreeViewTest, VisualCheck) {
     Button* themeBtn = new Button("Switch Theme", content);
     themeBtn->setFluentStyle(Button::Accent);
     themeBtn->setFixedSize(120, 32);
-    themeBtn->anchors()->top  = {tv4, Edge::Bottom, 24};
+    themeBtn->anchors()->top = {tv4, Edge::Bottom, 24};
     themeBtn->anchors()->right = {content, Edge::Right, -20};
     innerLayout->addWidget(themeBtn);
 
@@ -2496,9 +2609,10 @@ TEST_F(TreeViewTest, VisualCheck) {
     content->setMinimumHeight(1660);
 
     QObject::connect(themeBtn, &Button::clicked, [scrollArea, content]() {
-        fluent::FluentElement::setTheme(
-            fluent::FluentElement::currentTheme() == fluent::FluentElement::Light
-                ? fluent::FluentElement::Dark : fluent::FluentElement::Light);
+        fluent::FluentElement::setTheme(fluent::FluentElement::currentTheme() ==
+                                                fluent::FluentElement::Light
+                                            ? fluent::FluentElement::Dark
+                                            : fluent::FluentElement::Light);
         content->onThemeUpdated();
         scrollArea->setStyleSheet(content->styleSheet());
     });


### PR DESCRIPTION
Restore exact-once inherited pointer signals for collection views and Slider. Add focused regression coverage, including GridView programmatic preselection, and record the API compatibility contract. Verified locally: 300 tests passed, 15 manual or platform-dependent tests skipped, and Gallery plus repository validators passed. No version or release changes.