### PR TITLE
ci(cpp): add local formatting gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if command -v python3 >/dev/null 2>&1; then
+    python_command=python3
+elif command -v python >/dev/null 2>&1; then
+    python_command=python
+else
+    echo "FluentQt pre-commit: Python was not found." >&2
+    exit 2
+fi
+
+git diff --cached --check
+exec "$python_command" tools/quality/check_cpp_format.py --staged

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+remote_name=${1:-origin}
+base_ref=${FLUENTQT_FORMAT_BASE:-refs/remotes/$remote_name/main}
+
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+    echo "FluentQt pre-push: base ref '$base_ref' was not found." >&2
+    echo "Fetch it or set FLUENTQT_FORMAT_BASE to the pull-request base ref." >&2
+    exit 2
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python_command=python3
+elif command -v python >/dev/null 2>&1; then
+    python_command=python
+else
+    echo "FluentQt pre-push: Python was not found." >&2
+    exit 2
+fi
+
+status=0
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+    case "$local_sha" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    echo "FluentQt pre-push: checking $local_ref ($local_sha) against $base_ref"
+    git diff --check "$base_ref...$local_sha" -- || status=$?
+    if [ "$status" -eq 0 ]; then
+        "$python_command" tools/quality/check_cpp_format.py \
+            --changed-from "$base_ref" \
+            --head "$local_sha" || status=$?
+    fi
+done
+
+exit "$status"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,8 @@
 - [ ] Gallery examples, source snippets, installed headers, catalogs, and
       documentation remain aligned or are not applicable.
 - [ ] PySide6 support is included in this slice or an intentional C++-only boundary is documented.
+- [ ] I ran `python3 tools/quality/check_cpp_format.py --changed-from origin/main`
+      when the pull request changes C++ files.
 - [ ] I ran `git diff --check` and removed credentials, customer data, and private paths from the change and evidence.
 
 ## Screenshots or recordings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ ctest --preset vcpkg-osx --output-on-failure
   test_<name>` on Linux or `python3 tools/dev/fluent_qt_build.py --preset
   vcpkg-osx --target test_<name>` on macOS.
 - Prefer anchored CTest label filters, for example `ctest --preset vcpkg-linux -L '^test_<name>$' --output-on-failure`; see [docs/development/testing-workflow.md](docs/development/testing-workflow.md).
+- Before committing or pushing C++ changes, run the read-only local static gate documented in [docs/development/testing-workflow.md](docs/development/testing-workflow.md#local-static-gate); pull-request CI must remain the final gate, not the first formatter check.
 - VisualCheck tests are interactive by design. Automated CTest runs set `SKIP_VISUAL_TEST=1`; run binaries directly with `--gtest_filter="*VisualCheck*"` for manual review or `VISUAL_SNAPSHOT=1` for snapshots.
 
 ## Architecture Map

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,17 @@ or `fix(windowing): ...`; see [release governance](docs/development/release-gove
 
 ## Validate the smallest relevant surface
 
+Enable the repository's read-only local gates once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hooks run whitespace checks and the same changed-file C++ formatting
+contract used by CI before commits and pushes. See the
+[local static gate](docs/development/testing-workflow.md#local-static-gate) for
+manual check, fix, formatter-version, and fork-base commands.
+
 Configure with a supported preset, then build in parallel. On macOS arm64:
 
 ```bash
@@ -66,10 +77,11 @@ manual or snapshot runs. Changes that affect bindings or browser builds should
 also follow the [PySide6](bindings/pyside6/README.md) or
 [WebAssembly](docs/development/webassembly-workflow.md) workflow.
 
-Before requesting review, run `git diff --check`, describe what you tested, and
-call out any platform or surface you could not verify. Full cross-platform CI
-is expected on the pull request; contributors do not need every toolchain on
-one machine.
+Before requesting review, run
+`python3 tools/quality/check_cpp_format.py --changed-from origin/main` and
+`git diff --check`, describe what you tested, and call out any platform or
+surface you could not verify. Full cross-platform CI is expected on the pull
+request; contributors do not need every toolchain on one machine.
 
 <!-- docs-nav:bottom:start -->
 ---

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,6 +19,7 @@ so a dated roadmap cannot be mistaken for current guidance.
 | Add or edit a Gallery sample | [App sample optimization](app-sample-optimization.md) | [Live Scene and native preview](gallery-preview-workflow.md), [AI-assisted GUI verification](gui-verification-workflow.md) |
 | Add a Gallery card image | [Gallery control images](gallery-control-images.md) | qrc registration and Gallery build |
 | Build the repository locally | [Build workflow](build-workflow.md) | The selected job count printed by the adaptive wrapper |
+| Prepare a commit or pull request | [Testing workflow: local static gate](testing-workflow.md#local-static-gate) | Staged and branch-relative formatting checks |
 | Write or update a test | [Testing workflow](testing-workflow.md) | [Qt component test conventions](qt-component-test-conventions.md) |
 | Diagnose behavior | [Logging workflow](logging-workflow.md) | Focused component tests |
 | Change Linux or WebAssembly support | [Linux](linux-workflow.md) or [WebAssembly](webassembly-workflow.md) | The matching preset and CI lane |

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -106,6 +106,46 @@ Run the affected component labels and `visual_gate` after the extraction.
 VisualCheck remains a separate manual review surface; it does not replace
 automated state and pixel invariants.
 
+## Local static gate
+
+Run the C++ format contract before committing or pushing, rather than using
+pull-request CI as the first formatter. The check uses clang-format 15.0.0 and
+formats incrementally by complete touched file, so a legacy file may produce a
+larger mechanical diff the first time it is changed.
+
+Check the current working tree before staging, the exact staged snapshots
+before committing, or the committed pull-request diff before pushing:
+
+```bash
+python3 tools/quality/check_cpp_format.py --working-tree
+python3 tools/quality/check_cpp_format.py --staged
+git fetch origin main
+python3 tools/quality/check_cpp_format.py --changed-from origin/main
+```
+
+Use `--working-tree --fix` on the affected branch to update the working-tree
+copies, then review and stage the result. Keep a large mechanical rewrite in a
+separate `style` commit. `--staged` checks the index blobs and `--changed-from`
+checks the selected committed blobs, so unrelated unstaged edits cannot make
+either check pass.
+
+The formatter must report exactly `clang-format 15.0.0`. Set
+`FLUENTQT_CLANG_FORMAT=/absolute/path/to/clang-format` or pass
+`--clang-format PATH` when that executable is not the default on `PATH`.
+
+Enable the repository hooks once per clone to run the same checker
+automatically:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The pre-commit hook checks staged whitespace and C++ snapshots. The pre-push
+hook checks whitespace and C++ files in every revision being pushed relative
+to the pushed remote's `main` ref, even when it is not the currently checked
+out branch. Both hooks are read-only and never format files. Fork workflows can
+set `FLUENTQT_FORMAT_BASE` to a different local base ref.
+
 ## Validation Tiers
 
 The public [CI workflow](../../.github/workflows/ci.yml) is an orchestration

--- a/tools/quality/check_cpp_format.py
+++ b/tools/quality/check_cpp_format.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -21,6 +22,11 @@ def parse_clang_format_version(output: str) -> str | None:
     """Return the LLVM formatter version, ignoring wrapper version banners."""
     match = re.search(r"(?:^|\n)clang-format version (\d+(?:\.\d+){1,2})\b", output)
     return match.group(1) if match else None
+
+
+def default_formatter_command() -> str:
+    """Return the repository-specific formatter override or the PATH default."""
+    return os.environ.get("FLUENTQT_CLANG_FORMAT") or "clang-format"
 
 
 def is_cpp_path(path: Path) -> bool:
@@ -43,14 +49,14 @@ def normalize_cpp_files(paths: Iterable[str], *, require_exists: bool) -> list[P
     selected: set[Path] = set()
     for raw_path in paths:
         relative = _repo_relative(Path(raw_path), require_exists=require_exists)
-        if is_cpp_path(relative) and (PROJECT_ROOT / relative).is_file():
+        if is_cpp_path(relative):
             selected.add(relative)
     return sorted(selected)
 
 
-def changed_files_from(base: str) -> list[Path]:
+def changed_files_from(base: str, head: str = "HEAD") -> list[Path]:
     result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD", "--"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}", "--"],
         cwd=PROJECT_ROOT,
         check=False,
         capture_output=True,
@@ -116,6 +122,65 @@ def resolve_formatter(command: str) -> str:
     return executable
 
 
+def git_file_contents(revision: str, path: Path) -> bytes:
+    """Read one repository file from HEAD or the staged index."""
+    object_name = (
+        f":{path.as_posix()}"
+        if revision == "INDEX"
+        else f"{revision}:{path.as_posix()}"
+    )
+    result = subprocess.run(
+        ["git", "show", object_name],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"could not read {path} from {revision}: {detail}")
+    return result.stdout
+
+
+def print_fix_hint() -> None:
+    print(
+        "C++ formatting failed. Check out the affected branch, run "
+        "--working-tree --fix, review the whole-file diff, and stage the result again.",
+        file=sys.stderr,
+    )
+
+
+def check_git_files(executable: str, files: Sequence[Path], *, revision: str) -> int:
+    """Check committed or staged blobs without consulting working-tree copies."""
+    mismatches: list[Path] = []
+    for path in files:
+        original = git_file_contents(revision, path)
+        result = subprocess.run(
+            [
+                executable,
+                "--style=file",
+                f"--assume-filename={path.as_posix()}",
+            ],
+            cwd=PROJECT_ROOT,
+            check=False,
+            input=original,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.decode(errors="replace").strip()
+            raise RuntimeError(f"clang-format failed for {path}: {detail}")
+        if result.stdout != original:
+            mismatches.append(path)
+
+    if mismatches:
+        for path in mismatches:
+            print(f"{path}: requires clang-format", file=sys.stderr)
+        print_fix_hint()
+        return 1
+
+    print("C++ formatting passed.")
+    return 0
+
+
 def run_formatter(executable: str, files: Sequence[Path], *, fix: bool) -> int:
     if not files:
         print("No selected C++ files require formatting checks.")
@@ -132,6 +197,8 @@ def run_formatter(executable: str, files: Sequence[Path], *, fix: bool) -> int:
     result = subprocess.run(command, cwd=PROJECT_ROOT, check=False)
     if result.returncode == 0:
         print("C++ formatting passed." if not fix else "C++ formatting updated.")
+    elif not fix:
+        print_fix_hint()
     return result.returncode
 
 
@@ -146,7 +213,13 @@ def build_parser() -> argparse.ArgumentParser:
     selection.add_argument(
         "--changed-from",
         metavar="GIT_REF",
-        help="check C++ files changed between the merge base of GIT_REF and HEAD",
+        help="check C++ files changed between GIT_REF and the selected head revision",
+    )
+    parser.add_argument(
+        "--head",
+        default="HEAD",
+        metavar="GIT_REF",
+        help="revision to check with --changed-from (default: HEAD)",
     )
     selection.add_argument("--staged", action="store_true", help="check staged C++ files")
     selection.add_argument(
@@ -156,9 +229,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--clang-format",
-        default="clang-format",
+        default=default_formatter_command(),
         metavar="PATH",
-        help=f"formatter executable (must report version {EXPECTED_CLANG_FORMAT_VERSION})",
+        help=(
+            "formatter executable (must report version "
+            f"{EXPECTED_CLANG_FORMAT_VERSION}; defaults to FLUENTQT_CLANG_FORMAT "
+            "or clang-format)"
+        ),
     )
     parser.add_argument("--fix", action="store_true", help="format selected files in place")
     return parser
@@ -172,11 +249,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     if selection_count != 1:
         parser.error("provide explicit files or choose exactly one changed-file mode")
+    if args.head != "HEAD" and not args.changed_from:
+        parser.error("--head requires --changed-from")
+    if args.fix and args.head != "HEAD":
+        parser.error("--fix cannot update an arbitrary --head revision; check it out first")
     try:
+        git_revision: str | None = None
         if args.changed_from:
-            files = changed_files_from(args.changed_from)
+            files = changed_files_from(args.changed_from, args.head)
+            git_revision = args.head
         elif args.staged:
             files = staged_files()
+            git_revision = "INDEX"
         elif args.working_tree:
             files = working_tree_files()
         else:
@@ -186,6 +270,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("No selected C++ files require formatting checks.")
             return 0
         formatter = resolve_formatter(args.clang_format)
+        if git_revision is not None and not args.fix:
+            print(f"Checking {len(files)} C++ file(s) from {git_revision}...")
+            return check_git_files(formatter, files, revision=git_revision)
         return run_formatter(formatter, files, fix=args.fix)
     except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
         print(f"error: {error}", file=sys.stderr)

--- a/tools/quality/test_check_cpp_format.py
+++ b/tools/quality/test_check_cpp_format.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import os
+import stat
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 
 MODULE_PATH = Path(__file__).with_name("check_cpp_format.py")
+PROJECT_ROOT = MODULE_PATH.parents[2]
 SPEC = importlib.util.spec_from_file_location("check_cpp_format", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 check_cpp_format = importlib.util.module_from_spec(SPEC)
@@ -22,6 +27,17 @@ class CheckCppFormatTest(unittest.TestCase):
             "clang-format version 15.0.0 (https://github.com/llvm/llvm-project.git abc)\n"
         )
         self.assertEqual(check_cpp_format.parse_clang_format_version(output), "15.0.0")
+
+    def test_formatter_override_uses_repository_environment_variable(self) -> None:
+        with patch.dict(os.environ, {"FLUENTQT_CLANG_FORMAT": "/opt/tools/clang-format"}):
+            self.assertEqual(
+                check_cpp_format.default_formatter_command(),
+                "/opt/tools/clang-format",
+            )
+
+    def test_empty_formatter_override_falls_back_to_path_default(self) -> None:
+        with patch.dict(os.environ, {"FLUENTQT_CLANG_FORMAT": ""}):
+            self.assertEqual(check_cpp_format.default_formatter_command(), "clang-format")
 
     def test_normalize_cpp_files_filters_and_deduplicates(self) -> None:
         selected = check_cpp_format.normalize_cpp_files(
@@ -41,7 +57,7 @@ class CheckCppFormatTest(unittest.TestCase):
             check_cpp_format.normalize_cpp_files(["/private/tmp/outside.cpp"], require_exists=False)
 
     @patch.object(check_cpp_format.subprocess, "run")
-    def test_changed_files_are_filtered_to_existing_cpp_files(self, run) -> None:
+    def test_changed_files_trust_committed_cpp_paths_over_working_tree(self, run) -> None:
         run.return_value.returncode = 0
         run.return_value.stdout = (
             "README.md\n"
@@ -51,7 +67,10 @@ class CheckCppFormatTest(unittest.TestCase):
         run.return_value.stderr = ""
         self.assertEqual(
             check_cpp_format.changed_files_from("origin/main"),
-            [Path("src/components/basicinput/MultiSelectComboBox.h")],
+            [
+                Path("src/components/basicinput/MultiSelectComboBox.h"),
+                Path("src/components/basicinput/Removed.cpp"),
+            ],
         )
         self.assertEqual(
             run.call_args.args[0],
@@ -61,6 +80,28 @@ class CheckCppFormatTest(unittest.TestCase):
                 "--name-only",
                 "--diff-filter=ACMR",
                 "origin/main...HEAD",
+                "--",
+            ],
+        )
+
+    @patch.object(check_cpp_format.subprocess, "run")
+    def test_changed_files_accept_explicit_pushed_revision(self, run) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "src/example.cpp\n"
+        run.return_value.stderr = ""
+
+        self.assertEqual(
+            check_cpp_format.changed_files_from("origin/main", "abc123"),
+            [Path("src/example.cpp")],
+        )
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMR",
+                "origin/main...abc123",
                 "--",
             ],
         )
@@ -93,6 +134,101 @@ class CheckCppFormatTest(unittest.TestCase):
         run.return_value.stderr = ""
         with self.assertRaisesRegex(RuntimeError, "15.0.0 is required"):
             check_cpp_format.resolve_formatter("clang-format")
+
+    @patch.object(check_cpp_format.subprocess, "run")
+    def test_git_file_check_uses_exact_head_blob(self, run) -> None:
+        original = b"int value;\n"
+        run.side_effect = [
+            Mock(returncode=0, stdout=original, stderr=b""),
+            Mock(returncode=0, stdout=original, stderr=b""),
+        ]
+
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(
+                check_cpp_format.check_git_files(
+                    "/usr/bin/clang-format",
+                    [Path("src/example.cpp")],
+                    revision="HEAD",
+                ),
+                0,
+            )
+        self.assertEqual(
+            run.call_args_list[0].args[0],
+            ["git", "show", "HEAD:src/example.cpp"],
+        )
+        self.assertEqual(
+            run.call_args_list[1].args[0],
+            [
+                "/usr/bin/clang-format",
+                "--style=file",
+                "--assume-filename=src/example.cpp",
+            ],
+        )
+        self.assertEqual(run.call_args_list[1].kwargs["input"], original)
+
+    @patch.object(check_cpp_format.subprocess, "run")
+    def test_git_file_check_reports_format_mismatch(self, run) -> None:
+        run.side_effect = [
+            Mock(returncode=0, stdout=b"int  value;\n", stderr=b""),
+            Mock(returncode=0, stdout=b"int value;\n", stderr=b""),
+        ]
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(
+                check_cpp_format.check_git_files(
+                    "/usr/bin/clang-format",
+                    [Path("src/example.cpp")],
+                    revision="INDEX",
+                ),
+                1,
+            )
+        self.assertEqual(
+            run.call_args_list[0].args[0],
+            ["git", "show", ":src/example.cpp"],
+        )
+
+    @patch.object(check_cpp_format, "check_git_files", return_value=0)
+    @patch.object(check_cpp_format, "resolve_formatter", return_value="/usr/bin/clang-format")
+    @patch.object(
+        check_cpp_format,
+        "staged_files",
+        return_value=[Path("src/example.cpp")],
+    )
+    def test_staged_mode_checks_index_snapshot(self, _files, _resolve, check) -> None:
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(check_cpp_format.main(["--staged"]), 0)
+        check.assert_called_once_with(
+            "/usr/bin/clang-format",
+            [Path("src/example.cpp")],
+            revision="INDEX",
+        )
+
+    def test_fix_rejects_an_arbitrary_pushed_revision(self) -> None:
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaisesRegex(SystemExit, "2"):
+                check_cpp_format.main(
+                    [
+                        "--changed-from",
+                        "origin/main",
+                        "--head",
+                        "abc123",
+                        "--fix",
+                    ]
+                )
+
+    def test_repository_hooks_are_executable_and_share_the_checker(self) -> None:
+        expected = {
+            "pre-commit": "--staged",
+            "pre-push": "--changed-from",
+        }
+        for name, selection in expected.items():
+            with self.subTest(hook=name):
+                path = PROJECT_ROOT / ".githooks" / name
+                script = path.read_text(encoding="utf-8")
+                self.assertTrue(path.stat().st_mode & stat.S_IXUSR)
+                self.assertIn("tools/quality/check_cpp_format.py", script)
+                self.assertIn(selection, script)
+                self.assertIn("git diff", script)
 
     @patch.object(check_cpp_format, "resolve_formatter")
     @patch.object(check_cpp_format, "working_tree_files", return_value=[])


### PR DESCRIPTION
## Summary

- check exact staged and committed C++ snapshots with clang-format 15
- add read-only pre-commit and pre-push hooks that reuse the CI checker
- document local setup and require the branch-relative check before review

## Validation

- python3 tools/quality/test_check_cpp_format.py (15 passed)
- python3 .github/scripts/test_validate_ci_workflow_boundaries.py (71 passed)
- python3 tools/docs/validate_documentation.py --project-root . --self-test (7 passed)
- positive/negative pre-push replay against formatted and unformatted commits
- git diff --check origin/main...HEAD