### PR TITLE
ci(site): catch stale generated outputs before merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,8 @@
 - [ ] PySide6 support is included in this slice or an intentional C++-only boundary is documented.
 - [ ] I ran `python3 tools/quality/check_cpp_format.py --changed-from origin/main`
       when the pull request changes C++ files.
+- [ ] I ran the generated site freshness checks when public headers or site
+      inputs change.
 - [ ] I ran `git diff --check` and removed credentials, customer data, and private paths from the change and evidence.
 
 ## Screenshots or recordings

--- a/.github/scripts/test_validate_ci_workflow_boundaries.py
+++ b/.github/scripts/test_validate_ci_workflow_boundaries.py
@@ -78,6 +78,19 @@ class ValidateCiWorkflowBoundariesTest(unittest.TestCase):
     def test_repository_workflow_boundaries_are_valid(self):
         self.assertEqual(MODULE.validate_boundaries(), [])
 
+    def test_ci_plan_requires_generated_site_freshness_checks(self):
+        commands = (
+            "          python3 tools/site/generate_localized_site.py --check\n",
+            "          python3 tools/site/generate_api_reference.py --check\n",
+        )
+        for command in commands:
+            with self.subTest(command=command.strip()):
+                errors = self.workflow_errors_with_replacement("ci.yml", command, "")
+                self.assertTrue(
+                    any("missing orchestration contract" in error for error in errors),
+                    "ci.yml accepted a missing generated-site freshness check",
+                )
+
     def test_audited_third_party_actions_require_immutable_revisions(self):
         cases = (
             (

--- a/.github/scripts/validate-ci-workflow-boundaries.py
+++ b/.github/scripts/validate-ci-workflow-boundaries.py
@@ -1467,6 +1467,9 @@ def validate_boundaries() -> list[str]:
         "release_max_parallel: 4",
         "Require a current main base for release pull requests",
         ".github/scripts/check-release-branch-freshness.py",
+        "name: Validate generated site outputs",
+        "python3 tools/site/generate_localized_site.py --check",
+        "python3 tools/site/generate_api_reference.py --check",
         "actions: read",
     ):
         if required not in active_orchestrator:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
           python3 tools/onboarding/test_fluentqt_create.py
           python3 tools/onboarding/test_fluentqt_trial.py
           python3 -m unittest discover -s tools/dev -p 'test_fluent_qt_*.py'
+      - name: Validate generated site outputs
+        run: |
+          python3 tools/site/generate_localized_site.py --check
+          python3 tools/site/generate_api_reference.py --check
       - name: Require a current main base for release pull requests
         if: >-
           ${{

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,12 @@ also follow the [PySide6](bindings/pyside6/README.md) or
 
 Before requesting review, run
 `python3 tools/quality/check_cpp_format.py --changed-from origin/main` and
-`git diff --check`, describe what you tested, and call out any platform or
-surface you could not verify. Full cross-platform CI is expected on the pull
-request; contributors do not need every toolchain on one machine.
+`git diff --check`. When public headers or site inputs change, also run
+`python3 tools/site/generate_api_reference.py --check` and
+`python3 tools/site/generate_localized_site.py --check`. Describe what you
+tested and call out any platform or surface you could not verify. Full
+cross-platform CI is expected on the pull request; contributors do not need
+every toolchain on one machine.
 
 <!-- docs-nav:bottom:start -->
 ---

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,7 +19,7 @@ so a dated roadmap cannot be mistaken for current guidance.
 | Add or edit a Gallery sample | [App sample optimization](app-sample-optimization.md) | [Live Scene and native preview](gallery-preview-workflow.md), [AI-assisted GUI verification](gui-verification-workflow.md) |
 | Add a Gallery card image | [Gallery control images](gallery-control-images.md) | qrc registration and Gallery build |
 | Build the repository locally | [Build workflow](build-workflow.md) | The selected job count printed by the adaptive wrapper |
-| Prepare a commit or pull request | [Testing workflow: local static gate](testing-workflow.md#local-static-gate) | Staged and branch-relative formatting checks |
+| Prepare a commit or pull request | [Testing workflow: local static gate](testing-workflow.md#local-static-gate) | Staged formatting and generated-output freshness checks |
 | Write or update a test | [Testing workflow](testing-workflow.md) | [Qt component test conventions](qt-component-test-conventions.md) |
 | Diagnose behavior | [Logging workflow](logging-workflow.md) | Focused component tests |
 | Change Linux or WebAssembly support | [Linux](linux-workflow.md) or [WebAssembly](webassembly-workflow.md) | The matching preset and CI lane |

--- a/docs/development/site-workflow.md
+++ b/docs/development/site-workflow.md
@@ -43,20 +43,30 @@ the Pages layout so links from older posts and bookmarks continue to work.
 The generator owns `site/index.html`, `site/zh-CN/index.html`, and
 `site/sitemap.xml`. Do not edit those files directly.
 
+The API Explorer catalog is generated from the installed-header allowlist,
+installed public headers, and the generated AI catalog. After any of those
+inputs change, regenerate it instead of editing the JSON directly:
+
+```bash
+python3 tools/site/generate_api_reference.py
+```
+
 ## Validation
 
 Run the same freshness check used by the Pages workflow:
 
 ```bash
 python3 tools/site/generate_localized_site.py --check
+python3 tools/site/generate_api_reference.py --check
 ```
 
 The check requires matching translation keys, static localized text and
 attributes, valid JSON-LD and sitemap XML, canonical URLs, reciprocal
 `hreflang` links, the URL-owned 404 language contract, the legacy Gallery
 redirect, and the current CMake project version in structured data.
-The Pages workflow also verifies that both localized pages and `sitemap.xml`
-are present before deployment.
+The pull-request planning job runs both freshness checks before merge. The
+Pages workflow repeats them and also verifies that both localized pages and
+`sitemap.xml` are present before deployment.
 
 After deployment, verify both language URLs and submit `sitemap.xml` to the
 configured search-engine webmaster tools. Search Console ownership and sitemap

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -146,6 +146,15 @@ to the pushed remote's `main` ref, even when it is not the currently checked
 out branch. Both hooks are read-only and never format files. Fork workflows can
 set `FLUENTQT_FORMAT_BASE` to a different local base ref.
 
+Public-header and site changes must also keep the committed generated outputs
+current. Run these deterministic checks locally; the CI planning job repeats
+them before any pull request can merge, while Pages repeats them before deploy:
+
+```bash
+python3 tools/site/generate_localized_site.py --check
+python3 tools/site/generate_api_reference.py --check
+```
+
 ## Validation Tiers
 
 The public [CI workflow](../../.github/workflows/ci.yml) is an orchestration

--- a/site/api/catalog.json
+++ b/site/api/catalog.json
@@ -2938,6 +2938,8 @@
         "QTimer",
         "QWheelEvent",
         "QVariantAnimation",
+        "ScrollBar",
+        "OverscrollController",
         "FlowView",
         "LayoutBand"
       ],
@@ -2956,6 +2958,8 @@
         "QTimer",
         "QVariantAnimation",
         "QWheelEvent",
+        "ScrollBar",
+        "OverscrollController",
         "GridView"
       ],
       "source_url": "https://github.com/calvinhxx/Fluent-Qt/blob/main/src/components/collections/GridView.h"
@@ -2976,6 +2980,8 @@
         "QVariantAnimation",
         "QWheelEvent",
         "QPropertyAnimation",
+        "ScrollBar",
+        "OverscrollController",
         "ListView",
         "IndicatorMotionDirection"
       ],
@@ -3038,6 +3044,8 @@
         "QVariantAnimation",
         "QWheelEvent",
         "QTimer",
+        "ScrollBar",
+        "OverscrollController",
         "TreeView",
         "SelectionIndicatorStyle",
         "IndicatorVerticalDirection",


### PR DESCRIPTION
## Summary

- sync the generated API catalog after collection header formatting exposed two additional declarations
- run localized-site and API-catalog freshness checks in the pull-request planning job
- document the local freshness commands and guard the CI contract with a regression test

## Why

The post-merge main run built WebAssembly successfully, then Pages failed because `site/api/catalog.json` was stale. Pull-request CI did not run the same deterministic freshness check, so the drift was discovered too late.

## Validation

- `python3 .github/scripts/test_validate_ci_workflow_boundaries.py` (72 passed)
- `python3 .github/scripts/validate-ci-workflow-boundaries.py`
- `python3 .github/scripts/test_classify_ci_changes.py` (39 passed)
- `python3 tools/quality/test_check_cpp_format.py` (15 passed)
- `python3 tools/site/generate_localized_site.py --check`
- `python3 tools/site/generate_api_reference.py --check`
- `python3 tools/docs/validate_documentation.py --project-root . --self-test` (7 passed)
- `git diff --check`