### PR TITLE
ci(cpp): build native window probe for Windows platform tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,9 @@ set(FLUENT_QT_CI_WINDOWS_PLATFORM_TARGETS
     test_list_view
     test_flip_view
 )
+if(WIN32)
+    list(APPEND FLUENT_QT_CI_WINDOWS_PLATFORM_TARGETS test_window_win)
+endif()
 
 set(FLUENT_QT_CI_FULL_CONTRACT_TARGETS
     test_foundation_contracts


### PR DESCRIPTION
## Summary

Build `test_window_win` when the Windows platform CI aggregate is requested. The 1.8.1 full CI run selected the newly separated `WindowsWindowBackdropTest.StateChangesDoNotRepeatActivationCompensation` but could not find its executable because the aggregate omitted that target.

The dependency is added only on Windows. Existing test selection, skip conditions, and library code remain unchanged.

## Validation

- Build: `fluent_qt_ci_windows_platform_tests` configured and built on macOS arm64 / Qt 6.9.3; the Windows-specific dependency is conditional and requires the Windows CI lane.
- Automated checks: 10 C++ matrix validator tests, matrix validation, CI workflow boundary validation, and `git diff --check` passed.
- Visual or interaction review: not applicable to this build dependency change.
- Release gate: the final `main` commit must pass full CI and Release Candidate before `v1.8.1` is tagged.

Failure evidence: [Windows x64 / Qt 6.2 platform targeted](https://github.com/calvinhxx/Fluent-Qt/actions/runs/34016673497/job/101441617404).
